### PR TITLE
Source for local forage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "jquery": "~1.9.1",
     "qunit": "~1.12.0",
-    "rsvp": "~2.0.4"
+    "rsvp": "~2.0.4",
+    "localforage": "0.8.1"
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,6 +9,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
+      'vendor/localforage.js',
       'vendor/loader.js',
       'vendor/sinon.js',
       'vendor/jquery.js',

--- a/lib/orbit_common/local_forage_source.js
+++ b/lib/orbit_common/local_forage_source.js
@@ -13,9 +13,9 @@ var supportsLocalStorage = function() {
 };
 
 /**
- Source for storing data in local storage
-
- @class LocalStorageSource
+ Source for storing data with local forage (https://github.com/mozilla/localForage)
+ 
+ @class LocalForageSource
  @extends MemorySource
  @namespace OC
  @param {OC.Schema} schema
@@ -30,9 +30,9 @@ extend(LocalForageSource.prototype, MemorySource.prototype, {
   constructor: LocalForageSource,
 
   init: function(schema, options) {
-    assert('Your browser does not support local storage!', supportsLocalStorage());
-    assert('No valid localforage object given', options['localforage'] !== undefined);
-    assert('localforage requires Orbit.Promise be defined', Orbit.Promise);
+    assert('Your browser does not support local storage!', supportsLocalStorage()); //needed as final fallback
+    assert('No valid local forage object given', options['localforage'] !== undefined);
+    assert('Local forage requires Orbit.Promise be defined', Orbit.Promise);
 
     var _this = this;
     
@@ -96,7 +96,7 @@ extend(LocalForageSource.prototype, MemorySource.prototype, {
   /////////////////////////////////////////////////////////////////////////////
 
   _saveData: function(forceSave) {
-    var _this = this; //bind not supported on older browsers
+    var _this = this; //bind not supported in older browsers
     if (!this._autosave && !forceSave) {
       this._isDirty = true;
       return;

--- a/lib/orbit_common/local_forage_source.js
+++ b/lib/orbit_common/local_forage_source.js
@@ -1,0 +1,112 @@
+import Orbit from 'orbit/main';
+import { assert } from 'orbit/lib/assert';
+import { extend } from 'orbit/lib/objects';
+import MemorySource from './memory_source';
+
+
+var supportsLocalStorage = function() {
+  try {
+    return 'localStorage' in window && window['localStorage'] !== null;
+  } catch(e) {
+    return false;
+  }
+};
+
+/**
+ Source for storing data in local storage
+
+ @class LocalStorageSource
+ @extends MemorySource
+ @namespace OC
+ @param {OC.Schema} schema
+ @param {Object}    [options]
+ @constructor
+ */
+var LocalForageSource = function() {
+  this.init.apply(this, arguments);
+};
+
+extend(LocalForageSource.prototype, MemorySource.prototype, {
+  constructor: LocalForageSource,
+
+  init: function(schema, options) {
+    assert('Your browser does not support local storage!', supportsLocalStorage());
+    assert('No valid localforage object given', options['localforage'] !== undefined);
+    assert('localforage requires Orbit.Promise be defined', Orbit.Promise);
+
+    var _this = this;
+    
+    MemorySource.prototype.init.apply(this, arguments);
+
+    options = options || {};
+    this.saveDataCallback = options['saveDataCallback'];
+    this.loadDataCallback = options['loadDataCallback'];
+    this.namespace = options['namespace'] || 'orbit'; // local storage key
+    this._autosave = options['autosave'] !== undefined ? options['autosave'] : true;
+    var autoload = options['autoload'] !== undefined ? options['autoload'] : true;
+    this.localforage = options['localforage'];
+
+    this.localforage.config({
+      name        : 'myApp',
+      version     : 1.0,
+      size        : 4980736,
+      storeName   : 'keyvaluepairs',
+      description : 'orbitjs localforage adapter'
+    });
+
+    this._isDirty = false;
+
+    this.on('didTransform', function() {
+      return this._saveData().then(function(){
+        if (options.saveDataCallback) setTimeout(_this.saveDataCallback, 0);
+      });
+    }, this);
+
+    if (autoload) this.load().then(function() {
+      if (options.loadDataCallback) setTimeout(options.callback, 0);
+    });
+  },
+
+  load: function() {
+    var _this = this;
+    return new Orbit.Promise(function(resolve, reject) {
+      _this.localforage.getItem(this.namespace).then(function(storage){
+        _this.reset(JSON.parse(storage));
+        resolve();
+      });
+    });
+  },
+
+  enableAutosave: function() {
+    if (!this._autosave) {
+      this._autosave = true;
+      if (this._isDirty) this._saveData();
+    }
+  },
+
+  disableAutosave: function() {
+    if (this._autosave) {
+      this._autosave = false;
+    }
+  },
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Internals
+  /////////////////////////////////////////////////////////////////////////////
+
+  _saveData: function(forceSave) {
+    var _this = this; //bind not supported on older browsers
+    if (!this._autosave && !forceSave) {
+      this._isDirty = true;
+      return;
+    }
+    return this.localforage.setItem(this.namespace, JSON.stringify(this.retrieve())).then(
+      function() {
+        _this._isDirty = false;
+      }
+    );
+
+  }
+});
+
+export default LocalForageSource;

--- a/lib/orbit_common/local_forage_source.js
+++ b/lib/orbit_common/local_forage_source.js
@@ -43,14 +43,15 @@ extend(LocalForageSource.prototype, MemorySource.prototype, {
     this.loadDataCallback = options['loadDataCallback'];
     this.namespace = options['namespace'] || 'orbit'; // local storage key
     this._autosave = options['autosave'] !== undefined ? options['autosave'] : true;
+    this.webSQLSize = options['webSQLSize'] !== undefined ? options['webSQLSize'] : 4980736;
     var autoload = options['autoload'] !== undefined ? options['autoload'] : true;
     this.localforage = options['localforage'];
 
     this.localforage.config({
-      name        : 'myApp',
+      name        : 'orbitjs',
       version     : 1.0,
-      size        : 4980736,
-      storeName   : 'keyvaluepairs',
+      size        : this.webSQLSize,
+      storeName   : this.namespace,
       description : 'orbitjs localforage adapter'
     });
 
@@ -100,7 +101,7 @@ extend(LocalForageSource.prototype, MemorySource.prototype, {
       this._isDirty = true;
       return;
     }
-    return this.localforage.setItem(this.namespace, JSON.stringify(this.retrieve())).then(
+    return this.localforage.setItem(this.namespace, this.retrieve()).then(
       function() {
         _this._isDirty = false;
       }

--- a/tasks/options/browser.js
+++ b/tasks/options/browser.js
@@ -20,6 +20,9 @@ module.exports = {
           case 'orbit-common-local-storage':
             return 'OC.LocalStorageSource';
 
+          case 'orbit-common-local-forage':
+            return 'OC.LocalForageSource';
+
           default:
             this.fail.warn('Unrecognized file: `' + name + '`.');
         }
@@ -37,6 +40,9 @@ module.exports = {
 
           case 'orbit-common-local-storage':
             return 'orbit_common/local_storage_source';
+
+          case 'orbit-common-local-forage':
+            return 'orbit_common/local_forage_source';
 
           default:
             this.fail.warn('Unrecognized file: `' + name + '`.');

--- a/tasks/options/copy.js
+++ b/tasks/options/copy.js
@@ -12,6 +12,7 @@ module.exports = {
       cwd: 'bower_components/',
       src: ['jquery/jquery.js',
             'rsvp/rsvp.amd.js',
+            'localforage/dist/localforage.js',
             'qunit/qunit/qunit.js',
             'qunit/qunit/qunit.css'],
       dest: 'tmp/public/test/vendor/'

--- a/test/tests/orbit_common/unit/local_forage_source_test.js
+++ b/test/tests/orbit_common/unit/local_forage_source_test.js
@@ -1,0 +1,178 @@
+import Orbit from 'orbit/main';
+import Schema from 'orbit_common/schema';
+import LocalForageSource from 'orbit_common/local_forage_source';
+import { all, Promise } from 'rsvp';
+import { verifyLocalStorageContainsRecord, verifyLocalStorageIsEmpty } from 'test_helper';
+
+var source;
+
+///////////////////////////////////////////////////////////////////////////////
+
+module("OC - LocalForageSource", {
+  setup: function() {
+    Orbit.Promise = Promise;
+
+    var schema = new Schema({
+      models: {
+        planet: {}
+      }
+    });
+    var callback = function() {
+      console.log("callback");
+    };
+    source = new LocalForageSource(schema, {autoload: false, localforage: window.localforage, saveDataCallback: callback});
+  },
+
+  teardown: function() {
+    window.localforage.removeItem(source.namespace);
+    source = null;
+    Orbit.Promise = null;
+  }
+});
+
+test("it exists", function() {
+  ok(source);
+});
+
+test("#add - can insert records and assign ids", function() {
+  expect(6);
+
+  equal(source.length('planet'), 0, 'source should be empty');
+
+  stop();
+  console.log("start test");
+  source.add('planet', {name: 'Jupiter', classification: 'gas giant'}).then(function(planet) {
+    equal(source.length('planet'), 1, 'source should contain one record');
+    ok(planet.__id, 'id should be defined');
+    equal(planet.name, 'Jupiter', 'name should match');
+    equal(planet.classification, 'gas giant', 'classification should match');
+    return planet;
+
+  }).then(function(planet) {
+    source.find('planet', planet.__id).then(function(foundPlanet) {
+      start();
+      equal(foundPlanet.id, planet.id, 'record can be looked up by id');
+    });
+  });
+});
+/*
+test("#update - can update records", function() {
+  expect(8);
+
+  equal(source.length('planet'), 0, 'source should be empty');
+
+  var original;
+
+  stop();
+  source.add('planet', {name: 'Jupiter', classification: 'gas giant'}).then(function(planet) {
+    original = planet;
+    return source.update('planet', {__id: planet.__id, name: 'Earth', classification: 'terrestrial'}).then(function(updatedPlanet) {
+      equal(updatedPlanet.__id, planet.__id, '__id remains the same');
+      equal(updatedPlanet.name, 'Earth', 'name has been updated');
+      equal(updatedPlanet.classification, 'terrestrial', 'classification has been updated');
+      return updatedPlanet;
+    });
+
+  }).then(function(planet) {
+    verifyLocalStorageContainsRecord(source.namespace, 'planet', planet);
+    source.find('planet', planet.__id).then(function(foundPlanet) {
+      start();
+      equal(foundPlanet.__id, planet.__id, 'record can be looked up by __id');
+      equal(foundPlanet.name, 'Earth', 'name has been updated');
+      equal(foundPlanet.classification, 'terrestrial', 'classification has been updated');
+      return planet;
+    });
+  });
+});
+
+test("#patch - can patch records", function() {
+  expect(6);
+
+  equal(source.length('planet'), 0, 'source should be empty');
+
+  var original;
+
+  stop();
+  source.add('planet', {name: 'Jupiter', classification: 'gas giant'}).then(function(planet) {
+    original = planet;
+
+    source.patch('planet', planet.__id, 'name', 'Earth').then(function() {
+      verifyLocalStorageContainsRecord(source.namespace, 'planet', planet);
+      source.find('planet', planet.__id).then(function(foundPlanet) {
+        start();
+        strictEqual(foundPlanet, original, 'still the same object as the one originally inserted');
+        equal(foundPlanet.__id, planet.__id, 'record can be looked up by __id');
+        equal(foundPlanet.name, 'Earth', 'name has been updated');
+        equal(foundPlanet.classification, 'gas giant', 'classification has not been updated');
+      });
+    });
+  });
+});
+
+test("#remove - can delete records", function() {
+  expect(3);
+
+  equal(source.length('planet'), 0, 'source should be empty');
+
+  stop();
+  source.add('planet', {name: 'Jupiter', classification: 'gas giant'}).then(function(planet) {
+    equal(source.length('planet'), 1, 'source should contain one record');
+
+    source.remove('planet', planet.__id).then(function() {
+      start();
+      equal(source.length('planet'), 0, 'source should be empty');
+    });
+  });
+});
+
+test("#find - can find all records", function() {
+  expect(3);
+
+  equal(source.length('planet'), 0, 'source should be empty');
+
+  stop();
+  all([
+    source.add('planet', {name: 'Jupiter', classification: 'gas giant', atmosphere: true}),
+    source.add('planet', {name: 'Earth', classification: 'terrestrial', atmosphere: true}),
+    source.add('planet', {name: 'Mercury', classification: 'terrestrial', atmosphere: false})
+  ]).then(function() {
+    equal(source.length('planet'), 3, 'source should contain 3 records');
+
+    source.find('planet').then(function(planets) {
+      start();
+      equal(planets.length, 3, 'find() should return all records');
+    });
+  });
+});
+
+test("it can use a custom local storage namespace for storing data", function() {
+  expect(1);
+
+  source.namespace = 'planets';
+
+  stop();
+  source.add('planet', {name: 'Jupiter', classification: 'gas giant'}).then(function(planet) {
+    start();
+    verifyLocalStorageContainsRecord(source.namespace, 'planet', planet);
+  });
+});
+
+test("autosave can be disabled to delay writing to local storage", function() {
+  expect(4);
+
+  source.disableAutosave();
+
+  equal(source.length('planet'), 0, 'source should be empty');
+
+  stop();
+  source.add('planet', {name: 'Jupiter', classification: 'gas giant'}).then(function(planet) {
+    start();
+    equal(source.length('planet'), 1, 'source should contain one record');
+    verifyLocalStorageIsEmpty(source.namespace);
+
+    source.enableAutosave();
+    verifyLocalStorageContainsRecord(source.namespace, 'planet', planet);
+  });
+});
+
+*/

--- a/test/tests/orbit_common/unit/local_forage_source_test.js
+++ b/test/tests/orbit_common/unit/local_forage_source_test.js
@@ -157,8 +157,8 @@ test("it can use a custom local storage namespace for storing data", function() 
     verifyLocalForageContainsRecord(source.namespace, 'planet', planet);
   });
 });
-/*
-test("autosave can be disabled to delay writing to local storage", function() {
+
+test("autosave can be disabled to delay writing to local forage", function() {
   expect(4);
 
   source.disableAutosave();
@@ -175,4 +175,3 @@ test("autosave can be disabled to delay writing to local storage", function() {
     verifyLocalForageContainsRecord(source.namespace, 'planet', planet);
   });
 });
-*/

--- a/test/tests/test_helper.js
+++ b/test/tests/test_helper.js
@@ -26,4 +26,39 @@ var verifyLocalStorageIsEmpty = function(namespace) {
   }
 };
 
-export { verifyLocalStorageContainsRecord, verifyLocalStorageIsEmpty };
+var verifyLocalForageContainsRecord = function(namespace, type, record, ignoreFields) {
+  var expected = {};
+  expected[record.__id] = record;
+
+  stop();
+  window.localforage.getItem(namespace).then(function(obj){
+    var actual;
+    if (type) actual = obj[type];
+    if (ignoreFields) {
+      for (var i = 0, l = ignoreFields.length, field; i < l; i++) {
+        field = ignoreFields[i];
+        actual[record.__id][field] = record[field];
+      }
+    }
+    deepEqual(actual,
+              expected,
+              'data in local forage matches expectations');
+    start();
+  });
+
+};
+
+var verifyLocalForageIsEmpty = function(namespace) {
+  stop();
+  window.localforage.getItem(namespace).then(function(contents){
+    if (contents === null) {
+      equal(contents, null, 'local forage should still be empty');
+    } else {
+      deepEqual(contents, {}, 'local forage should still be empty');
+    }
+    start();
+  });
+
+};
+
+export { verifyLocalStorageContainsRecord, verifyLocalStorageIsEmpty, verifyLocalForageContainsRecord, verifyLocalForageIsEmpty };


### PR DESCRIPTION
Local forage (https://github.com/mozilla/localForage) is a wrapper library for client side databases. The API is pretty similar to local storage. If supported, it will use the indexedDB/webSQL of the browser. It might be an alternative for use cases, where not all the flexibility of indexedDB is required, so I think both sources have their right to exist. 

This is work in progress, feedback is welcome!

Todo:
- refactoring of the local forage tests, because the tests use basically just a copy of the local storage tests (localforage is configured in this case to just use localstorage). What would be the best way to refactor these tests?
- maybe support customization of drivers
 