### PR TITLE
Rename package and repo to `orbit-core`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,18 +87,6 @@ non-blocking (i.e. associated actions are resolved in the background without
 blocking the flow of the application). Connectors can be used to enable
 uni or bi-directional flow of data between sources.
 
-## Orbit Common Library
-
-The Orbit Common library (namespaced `OC` by default) contains a set of
-compatible data sources, currently including: an in-memory cache, a local
-storage source, and a source for accessing [JSON API](http://jsonapi.org/)
-compliant APIs with AJAX.
-
-You can define your own data sources that will work with Orbit as long as they
-support Orbit's interfaces. You can either make sources compliant with the
-Orbit Common library or use Orbit's base interfaces to create an independent
-collection of compatible sources.
-
 ## Contributing
 
 ### Installing Orbit

--- a/package.json
+++ b/package.json
@@ -1,29 +1,22 @@
 {
-  "name": "orbit.js",
+  "name": "orbit-core",
   "private": true,
   "version": "0.8.0-beta.1",
-  "namespace": "Orbit",
-  "description": "A client-side library for data access and synchronization",
-  "homepage": "https://github.com/orbitjs/orbit.js",
-  "readmeFilename": "README.md",
+  "description": "Core library for Orbit.js, the flexible data access and synchronization layer.",
+  "homepage": "https://github.com/orbitjs/orbit-core",
   "author": {
     "name": "Cerebris Corporation",
     "url": "http://cerebris.com"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/orbitjs/orbit.js.git"
+    "url": "git://github.com/orbitjs/orbit-core.git"
   },
   "bugs": {
-    "url": "https://github.com/orbitjs/orbit.js/issues"
+    "url": "https://github.com/orbitjs/orbit-core/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/orbitjs/orbit.js/blob/master/LICENSE"
-    }
-  ],
-  "main": "Brocfile.js",
+  "keywords": ["orbit.js", "data", "synchronization"],
+  "licenses": "MIT",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=test broccoli build dist",
     "test": "testem ci",


### PR DESCRIPTION
In preparation for publishing to npm as `orbit-core` and extracting `orbit-jsonapi` and
`orbit-local-storage` as separate packages.