### PR TITLE
Introduce Bucket class.

### DIFF
--- a/src/action-queue.js
+++ b/src/action-queue.js
@@ -47,10 +47,12 @@ import { assert } from './lib/assert';
  @constructor
  */
 export default class ActionQueue {
-  constructor(options) {
+  constructor(target, options = {}) {
     assert('ActionQueue requires Orbit.Promise to be defined', Orbit.Promise);
 
-    options = options || {};
+    this.target = target;
+
+    this.name = options.name;
     this.autoProcess = options.autoProcess !== undefined ? options.autoProcess : true;
     this._actions = [];
   }
@@ -79,8 +81,8 @@ export default class ActionQueue {
            !current.settled;
   }
 
-  push(_action) {
-    let action = Action.from(_action);
+  push(method, options) {
+    const action = new Action(this.target, method, options);
     this._actions.push(action);
     if (this.autoProcess) { this.process(); }
     return action;
@@ -109,9 +111,9 @@ export default class ActionQueue {
     return this._actions.shift();
   }
 
-  unshift(_action) {
+  unshift(method, options) {
+    const action = new Action(this.target, method, options);
     this._cancel();
-    let action = Action.from(_action);
     this._actions.unshift(action);
     return action;
   }

--- a/src/action-queue.js
+++ b/src/action-queue.js
@@ -53,8 +53,14 @@ export default class ActionQueue {
     this.target = target;
 
     this.name = options.name;
+    this.bucket = options.bucket;
     this.autoProcess = options.autoProcess !== undefined ? options.autoProcess : true;
-    this._actions = [];
+    this._reify()
+      .then(() => {
+        if (this.length > 0 && this.autoProcess) {
+          this.process();
+        }
+      });
   }
 
   get length() {
@@ -82,59 +88,97 @@ export default class ActionQueue {
   }
 
   push(method, options) {
-    const action = new Action(this.target, method, options);
-    this._actions.push(action);
-    if (this.autoProcess) { this.process(); }
-    return action;
+    return this.reified
+      .then(() => {
+        const action = new Action(this.target, method, options);
+        this._actions.push(action);
+        return this._persist()
+          .then(() => {
+            if (this.autoProcess) {
+              return this.process()
+                .then(() => action);
+            } else {
+              return action;
+            }
+          });
+      });
   }
 
   retry() {
-    this._cancel();
-    this.current.reset();
-    return this.process();
+    return this.reified
+      .then(() => {
+        this._cancel();
+        this.current.reset();
+        return this._persist();
+      })
+      .then(() => this.process());
   }
 
   skip() {
-    this._cancel();
-    this._actions.shift();
-    return this.process();
+    return this.reified
+      .then(() => {
+        this._cancel();
+        this._actions.shift();
+        return this._persist();
+      })
+      .then(() => this.process());
   }
 
   clear() {
-    this._cancel();
-    this._actions = [];
-    return this.process();
+    return this.reified
+      .then(() => {
+        this._cancel();
+        this._actions = [];
+        return this._persist();
+      })
+      .then(() => this.process());
   }
 
   shift() {
-    this._cancel();
-    return this._actions.shift();
+    let action;
+
+    return this.reified
+      .then(() => {
+        this._cancel();
+        action = this._actions.shift();
+        return this._persist();
+      })
+      .then(() => action);
   }
 
   unshift(method, options) {
-    const action = new Action(this.target, method, options);
-    this._cancel();
-    this._actions.unshift(action);
-    return action;
+    let action;
+
+    return this.reified
+      .then(() => {
+        action = new Action(this.target, method, options);
+        this._cancel();
+        this._actions.unshift(action);
+        return this._persist();
+      })
+      .then(() => action);
   }
 
   process() {
-    let resolution = this._resolution;
+    return this.reified
+      .then(() => {
+        let resolution = this._resolution;
 
-    if (!resolution) {
-      if (this._actions.length === 0) {
-        resolution = Orbit.Promise.resolve();
-        this._complete();
-      } else {
-        this._error = null;
-        this._resolution = resolution = new Orbit.Promise((resolve) => {
-          this._resolve = resolve;
-        });
-        this._settleEach(resolution);
-      }
-    }
+        if (!resolution) {
+          if (this._actions.length === 0) {
+            resolution = Orbit.Promise.resolve();
+            this._complete();
+          } else {
+            this._error = null;
+            this._resolution = resolution = new Orbit.Promise((resolve) => {
+              this._resolve = resolve;
+            });
+            this._settleEach(resolution);
+          }
+        }
 
-    return resolution;
+        return resolution;
+      });
   }
 
   _complete() {
@@ -172,8 +216,11 @@ export default class ActionQueue {
         .then(() => {
           if (resolution === this._resolution) {
             this._actions.shift();
-            this.emit('action', action);
-            this._settleEach(resolution);
+            this._persist()
+              .then(() => {
+                this.emit('action', action);
+                this._settleEach(resolution);
+              });
           }
         })
         .catch((e) => {
@@ -181,6 +228,39 @@ export default class ActionQueue {
             this._fail(action, e);
           }
         });
+    }
+  }
+
+  _reify() {
+    this._actions = [];
+
+    if (this.bucket) {
+      this.reified = this.bucket.getItem(this.name)
+        .then(serialized => this._deserializeActions(serialized));
+    } else {
+      this.reified = Orbit.Promise.resolve();
+    }
+
+    return this.reified;
+  }
+
+  _deserializeActions(serialized) {
+    if (serialized) {
+      this._actions = serialized.map(a => Action.deserialize(this.target, a));
+    } else {
+      this._actions = [];
+    }
+  }
+
+  _serializeActions() {
+    return this._actions.map(a => a.serialize());
+  }
+
+  _persist() {
+    if (this.bucket) {
+      return this.bucket.setItem(this.name, this._serializeActions());
+    } else {
+      return Orbit.Promise.resolve();
     }
   }
 }

--- a/src/action.js
+++ b/src/action.js
@@ -18,17 +18,25 @@ import Orbit from './main';
 
  @class Action
  @namespace Orbit
- @param {Object}    [options]
- @param {Object}    [options.id] Optional identifier
- @param {Object}    [options.data] Optional data
- @param {Object}    [options.process] A function that performs the action
- @constructor
  */
+
 export default class Action {
-  constructor(options) {
-    this.id = options.id;
+  /**
+   * Constructor for `Action` class.
+   *
+   * @param  {Object} target         Target object
+   * @param  {String} method         Name of method to call on `target`
+   * @param  {Object} [options={}]   Options
+   * @param  {Any}    [options.meta] Optional metadata
+   * @param  {Any}    [options.data] Optional data to send as an arg when calling `method`
+   * @constructor
+   */
+  constructor(target, method, options = {}) {
+    this.target = target;
+    this.method = method;
+    this.meta = options.meta;
     this.data = options.data;
-    this._process = options.process;
+
     this.reset();
   }
 
@@ -65,7 +73,14 @@ export default class Action {
       this._started = true;
 
       try {
-        let ret = this._process();
+        const method = this.target[this.method];
+
+        let ret;
+        if (this.data) {
+          ret = method.call(this.target, this.data);
+        } else {
+          ret = method.call(this.target);
+        }
 
         if (ret && ret.then) {
           ret.then(this._success, this._fail);
@@ -80,11 +95,3 @@ export default class Action {
     return this.settle();
   }
 }
-
-Action.from = function(actionOrOptions) {
-  if (actionOrOptions instanceof Action) {
-    return actionOrOptions;
-  } else {
-    return new Action(actionOrOptions);
-  }
-};

--- a/src/action.js
+++ b/src/action.js
@@ -94,4 +94,16 @@ export default class Action {
 
     return this.settle();
   }
+
+  serialize() {
+    const { method, data, meta } = this;
+    return { method, data, meta };
+  }
+
+  static deserialize(target, serialized) {
+    return new Action(target, serialized.method, {
+      data: serialized.data,
+      meta: serialized.meta
+    });
+  }
 }

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -1,0 +1,22 @@
+/**
+ * Buckets are used by sources to persist transient state, such as logs and
+ * queues, that should not be lost in the event of an unexpected exception or
+ * shutdown.
+ */
+export default class Bucket {
+  constructor(options = {}) {
+    this.name = options.name;
+  }
+
+  getItem(/* key */) {
+    console.error('Bucket#getItem not implemented');
+  }
+
+  setItem(/* key, value */) {
+    console.error('Bucket#setItem not implemented');
+  }
+
+  removeItem(/* key */) {
+    console.error('Bucket#removeItem not implemented');
+  }
+}

--- a/src/transform/log.js
+++ b/src/transform/log.js
@@ -1,18 +1,13 @@
 /* globals Immutable */
+import Orbit from '../main';
 import Evented from '../evented';
 import { TransformNotLoggedException, OutOfRangeException } from '../lib/exceptions';
 
 export default class TransformLog {
-  constructor(data) {
-    if (data) {
-      if (Immutable.List.isList(data)) {
-        this._data = data;
-      } else {
-        this._data = new Immutable.List(data);
-      }
-    } else {
-      this._data = new Immutable.List();
-    }
+  constructor(data, options = {}) {
+    this.name = options.name;
+    this.bucket = options.bucket;
+    this._reify(data);
   }
 
   get data() {
@@ -31,78 +26,146 @@ export default class TransformLog {
     return this._data.size;
   }
 
-  append(transformId) {
-    const data = this._data;
+  append(...transformIds) {
+    let data;
 
-    this._data = data.push(transformId);
-
-    this.emit('append', transformId, data);
+    return this.reified
+      .then(() => {
+        data = this._data;
+        this._data = data.push(...transformIds);
+        return this._persist();
+      })
+      .then(() => {
+        this.emit('append', transformIds, data);
+      });
   }
 
   before(transformId, relativePosition = 0) {
-    const index = this._indexOf(transformId);
+    const index = this._data.indexOf(transformId);
+    if (index === -1) {
+      throw new TransformNotLoggedException(transformId);
+    }
+
     const position = index + relativePosition;
-    if (position < 0 || position >= this._data.size) { this._throwOutOfRange(position); }
+    if (position < 0 || position >= this._data.size) {
+      throw new OutOfRangeException(position);
+    }
 
     return this._data.slice(0, position).toJS();
   }
 
   after(transformId, relativePosition = 0) {
-    const index = this._indexOf(transformId);
+    const index = this._data.indexOf(transformId);
+    if (index === -1) {
+      throw new TransformNotLoggedException(transformId);
+    }
+
     const position = index + 1 + relativePosition;
-    if (position < 0 || position > this._data.size) { this._throwOutOfRange(position); }
+    if (position < 0 || position > this._data.size) {
+      throw new OutOfRangeException(position);
+    }
 
     return this._data.slice(position).toJS();
   }
 
   truncate(transformId, relativePosition = 0) {
-    const data = this._data;
-    const index = this._indexOf(transformId);
-    const position = index + relativePosition;
-    if (position < 0 || position > this._data.size) { this._throwOutOfRange(position); }
+    let data;
 
-    if (position === this._data.length) {
-      this._data = data.clear();
-    } else {
-      this._data = data.slice(position);
-    }
+    return this.reified
+      .then(() => {
+        data = this._data;
+        const index = this._data.indexOf(transformId);
+        if (index === -1) {
+          throw new TransformNotLoggedException(transformId);
+        }
 
-    this.emit('truncate', transformId, relativePosition, data);
+        const position = index + relativePosition;
+        if (position < 0 || position > this._data.size) {
+          throw new OutOfRangeException(position);
+        }
+
+        if (position === this._data.length) {
+          this._data = data.clear();
+        } else {
+          this._data = data.slice(position);
+        }
+
+        return this._persist();
+      })
+      .then(() => {
+        this.emit('truncate', transformId, relativePosition, data);
+      });
   }
 
   rollback(transformId, relativePosition = 0) {
-    const data = this._data;
-    const index = this._indexOf(transformId);
-    const position = index + 1 + relativePosition;
-    if (position < 0 || position > this._data.size) { this._throwOutOfRange(position); }
+    let data;
 
-    this._data = data.setSize(position);
+    return this.reified
+      .then(() => {
+        data = this._data;
+        const index = this._data.indexOf(transformId);
+        if (index === -1) {
+          throw new TransformNotLoggedException(transformId);
+        }
 
-    this.emit('rollback', transformId, relativePosition, data);
+        const position = index + 1 + relativePosition;
+        if (position < 0 || position > this._data.size) {
+          throw new OutOfRangeException(position);
+        }
+
+        this._data = data.setSize(position);
+
+        return this._persist();
+      })
+      .then(() => {
+        this.emit('rollback', transformId, relativePosition, data);
+      });
   }
 
   clear() {
-    const data = this._data;
-    this._data = data.clear();
+    let data;
 
-    this.emit('clear', data);
+    return this.reified
+      .then(() => {
+        data = this._data;
+        this._data = data.clear();
+        return this._persist();
+      })
+      .then(() => this.emit('clear', data));
   }
 
   contains(transformId) {
     return this._data.includes(transformId);
   }
 
-  _indexOf(transformId) {
-    const index = this._data.indexOf(transformId);
-    return index !== -1 ? index : this._throwTransformNotLogged(transformId);
+  _persist() {
+    if (this.bucket) {
+      return this.bucket.setItem(this.name, this._data.toJS());
+    } else {
+      return Orbit.Promise.resolve();
+    }
   }
 
-  _throwTransformNotLogged(transformId) {
-    throw new TransformNotLoggedException(transformId);
+  _reify(data) {
+    if (!data && this.bucket) {
+      this.reified = this.bucket.getItem(this.name)
+        .then(bucketData => this._initData(bucketData));
+    } else {
+      this._initData(data);
+      this.reified = Orbit.Promise.resolve();
+    }
   }
 
-  _throwOutOfRange(position) {
-    throw new OutOfRangeException(position);
+  _initData(data) {
+    if (data) {
+      if (Immutable.List.isList(data)) {
+        this._data = data;
+      } else {
+        this._data = new Immutable.List(data);
+      }
+    } else {
+      this._data = new Immutable.List();
+    }
   }
 }
 

--- a/test/tests/support/fake-bucket.js
+++ b/test/tests/support/fake-bucket.js
@@ -1,0 +1,28 @@
+import Orbit from 'orbit';
+import Bucket from 'orbit/bucket';
+
+/**
+ * A simple implementation of a Bucket that saves values to an in-memory
+ * object. Not practical, since Buckets are intended to persist values from
+ * memory, but useful for testing.
+ */
+export default class FakeBucket extends Bucket {
+  constructor(options = {}) {
+    super(options);
+    this.data = {};
+  }
+
+  getItem(key) {
+    return Orbit.Promise.resolve(this.data[key]);
+  }
+
+  setItem(key, value) {
+    this.data[key] = value;
+    return Orbit.Promise.resolve();
+  }
+
+  removeItem(key) {
+    delete this.data[key];
+    return Orbit.Promise.resolve();
+  }
+}

--- a/test/tests/test-helper.js
+++ b/test/tests/test-helper.js
@@ -16,6 +16,8 @@ import {
 
 import { planetsSchema } from './support/schemas';
 
+import FakeBucket from './support/fake-bucket';
+
 import './support/rsvp';
 
 export {
@@ -24,5 +26,6 @@ export {
   op,
   successfulOperation,
   failedOperation,
-  planetsSchema
+  planetsSchema,
+  FakeBucket
 };

--- a/test/tests/unit/action-queue-test.js
+++ b/test/tests/unit/action-queue-test.js
@@ -1,548 +1,670 @@
-import 'tests/test-helper';
 import ActionQueue from 'orbit/action-queue';
 import Evented from 'orbit/evented';
+import { FakeBucket } from 'tests/test-helper';
 import { Promise } from 'rsvp';
 
 ///////////////////////////////////////////////////////////////////////////////
 
-module('Orbit - ActionQueue', {});
+module('ActionQueue', function() {
+  test('can be instantiated', function(assert) {
+    const target = {};
+    const queue = new ActionQueue(target);
+    assert.ok(queue);
+  });
 
-test('can be instantiated', function() {
-  const target = {};
-  const queue = new ActionQueue(target);
-  ok(queue);
-});
+  test('#autoProcess is enabled by default', function(assert) {
+    const target = {};
+    const queue = new ActionQueue(target);
+    assert.equal(queue.autoProcess, true, 'autoProcess === true');
+  });
 
-test('#autoProcess is enabled by default', function() {
-  const target = {};
-  const queue = new ActionQueue(target);
-  equal(queue.autoProcess, true, 'autoProcess === true');
-});
+  test('auto-processes pushed actions sequentially by default', function(assert) {
+    assert.expect(21);
+    const done = assert.async();
+    let order = 0;
 
-test('auto-processes pushed actions sequentially by default', function(assert) {
-  assert.expect(23);
-  const done = assert.async();
-  let order = 0;
-
-  const target = {
-    _transform(op) {
-      transformCount++;
-      if (transformCount === 1) {
-        assert.equal(order++, 1, '_transform - op1 - order');
-        assert.strictEqual(op, op1, '_transform - op1 passed as argument');
-      } else if (transformCount === 2) {
-        assert.equal(order++, 4, '_transform - op2 - order');
-        assert.strictEqual(op, op2, '_transform - op2 passed as argument');
+    const target = {
+      _transform(op) {
+        transformCount++;
+        if (transformCount === 1) {
+          assert.equal(order++, 1, '_transform - op1 - order');
+          assert.strictEqual(op, op1, '_transform - op1 passed as argument');
+        } else if (transformCount === 2) {
+          assert.equal(order++, 4, '_transform - op2 - order');
+          assert.strictEqual(op, op2, '_transform - op2 passed as argument');
+        }
       }
-    }
-  };
+    };
 
-  const queue = new ActionQueue(target);
+    const queue = new ActionQueue(target);
 
-  let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
-  let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
-  let transformCount = 0;
+    let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
+    let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+    let transformCount = 0;
 
-  queue.on('beforeAction', function(action) {
-    if (transformCount === 0) {
-      assert.equal(order++, 0, 'op1 - order of beforeAction event');
-      assert.strictEqual(action.data, op1, 'op1 - beforeAction - data correct');
-      assert.strictEqual(queue.current, action, 'op1 - beforeAction - current action matches expectation');
-      assert.equal(queue.length, 1, 'op1 - beforeAction - queue length');
-    } else if (transformCount === 1) {
-      assert.equal(order++, 3, 'op2 - order of beforeAction event');
-      assert.strictEqual(action.data, op2, 'op2 - beforeAction - data correct');
-      assert.strictEqual(queue.current, action, 'op2 - beforeAction - current action matches expectation');
-      assert.equal(queue.length, 1, 'op2 - beforeAction - queue length');
-    }
-  });
-
-  queue.on('action', function(action) {
-    if (transformCount === 1) {
-      assert.equal(order++, 2, 'op1 - order of action event');
-      assert.strictEqual(action.data, op1, 'op1 processed');
-      assert.equal(queue.length, 1, 'op1 - after action - queue length');
-      assert.strictEqual(queue.current.data, op2, 'after op1 - current action is op2');
-      assert.equal(queue.processing, false, 'after op1 - queue.processing === false between actions');
-    } else if (transformCount === 2) {
-      assert.equal(order++, 5, 'op2 - order of action event');
-      assert.strictEqual(action.data, op2, 'op2 processed');
-      assert.equal(queue.length, 0, 'op2 - after action - queue length');
-      assert.strictEqual(queue.current, undefined, 'after op2 - current action is empty');
-      assert.equal(queue.processing, false, 'after op2 - queue.processing === false');
-    }
-  });
-
-  queue.on('complete', function() {
-    assert.equal(order++, 6, 'order of complete event');
-    done();
-  });
-
-  queue.push('_transform', {
-    id: 1,
-    data: op1
-  });
-
-  queue.push('_transform', {
-    id: 2,
-    data: op2
-  });
-});
-
-test('with `autoProcess` disabled, will process pushed functions sequentially when `process` is called', function(assert) {
-  assert.expect(5);
-  const done = assert.async();
-
-  const target = {
-    _transform(op) {
-      transformCount++;
-      if (transformCount === 1) {
-        assert.strictEqual(op, op1, '_transform - op1 passed as argument');
-      } else if (transformCount === 2) {
-        assert.strictEqual(op, op2, '_transform - op2 passed as argument');
+    queue.on('beforeAction', function(action) {
+      if (transformCount === 0) {
+        assert.equal(order++, 0, 'op1 - order of beforeAction event');
+        assert.strictEqual(action.data, op1, 'op1 - beforeAction - data correct');
+        assert.strictEqual(queue.current, action, 'op1 - beforeAction - current action matches expectation');
+      } else if (transformCount === 1) {
+        assert.equal(order++, 3, 'op2 - order of beforeAction event');
+        assert.strictEqual(action.data, op2, 'op2 - beforeAction - data correct');
+        assert.strictEqual(queue.current, action, 'op2 - beforeAction - current action matches expectation');
       }
-    }
-  };
+    });
 
-  const queue = new ActionQueue(target);
+    queue.on('action', function(action) {
+      if (transformCount === 1) {
+        assert.equal(order++, 2, 'op1 - order of action event');
+        assert.strictEqual(action.data, op1, 'op1 processed');
+        assert.equal(queue.length, 1, 'op1 - after action - queue length');
+        assert.strictEqual(queue.current.data, op2, 'after op1 - current action is op2');
+        assert.equal(queue.processing, false, 'after op1 - queue.processing === false between actions');
+      } else if (transformCount === 2) {
+        assert.equal(order++, 5, 'op2 - order of action event');
+        assert.strictEqual(action.data, op2, 'op2 processed');
+        assert.equal(queue.length, 0, 'op2 - after action - queue length');
+        assert.strictEqual(queue.current, undefined, 'after op2 - current action is empty');
+        assert.equal(queue.processing, false, 'after op2 - queue.processing === false');
+      }
+    });
 
-  let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
-  let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
-  let transformCount = 0;
+    queue.on('complete', function() {
+      assert.equal(order++, 6, 'order of complete event');
+      done();
+    });
 
-  queue.on('action', function(action) {
-    if (transformCount === 1) {
-      assert.strictEqual(action.data, op1, 'op1 processed');
-    } else if (transformCount === 2) {
-      assert.strictEqual(action.data, op2, 'op2 processed');
-    }
+    queue.push('_transform', {
+      id: 1,
+      data: op1
+    });
+
+    queue.push('_transform', {
+      id: 2,
+      data: op2
+    });
   });
 
-  queue.on('complete', function() {
-    assert.ok(true, 'queue completed');
-    done();
+  test('with `autoProcess` disabled, will process pushed functions sequentially when `process` is called', function(assert) {
+    assert.expect(5);
+    const done = assert.async();
+
+    const target = {
+      _transform(op) {
+        transformCount++;
+        if (transformCount === 1) {
+          assert.strictEqual(op, op1, '_transform - op1 passed as argument');
+        } else if (transformCount === 2) {
+          assert.strictEqual(op, op2, '_transform - op2 passed as argument');
+        }
+      }
+    };
+
+    const queue = new ActionQueue(target);
+
+    let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
+    let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+    let transformCount = 0;
+
+    queue.on('action', function(action) {
+      if (transformCount === 1) {
+        assert.strictEqual(action.data, op1, 'op1 processed');
+      } else if (transformCount === 2) {
+        assert.strictEqual(action.data, op2, 'op2 processed');
+      }
+    });
+
+    queue.on('complete', function() {
+      assert.ok(true, 'queue completed');
+      done();
+    });
+
+    queue.push('_transform', {
+      id: 1,
+      data: op1
+    });
+
+    queue.push('_transform', {
+      id: 2,
+      data: op2
+    });
+
+    queue.process();
   });
 
-  queue.push('_transform', {
-    id: 1,
-    data: op1
-  });
+  test('can enqueue actions while another action is being processed', function(assert) {
+    assert.expect(9);
+    const done = assert.async();
 
-  queue.push('_transform', {
-    id: 2,
-    data: op2
-  });
-
-  queue.process();
-});
-
-test('can enqueue actions while another action is being processed', function(assert) {
-  expect(9);
-  const done = assert.async();
-
-  const target = {
-    _transform(op) {
-      let promise;
-      if (op === op1) {
-        equal(++order, 1, '_transform with op1');
-        promise = new Promise(function(resolve) {
-          trigger.on('start1', function() {
-            equal(++order, 2, '_transform with op1 resolved');
+    const target = {
+      _transform(op) {
+        let promise;
+        if (op === op1) {
+          equal(++order, 1, '_transform with op1');
+          promise = new Promise(function(resolve) {
+            trigger.on('start1', function() {
+              equal(++order, 2, '_transform with op1 resolved');
+              resolve();
+            });
+          });
+        } else if (op === op2) {
+          equal(++order, 4, '_transform with op2');
+          promise = new Promise(function(resolve) {
+            equal(++order, 5, '_transform with op2 resolved');
             resolve();
           });
-        });
-      } else if (op === op2) {
-        equal(++order, 4, '_transform with op1');
-        promise = new Promise(function(resolve) {
-          equal(++order, 5, '_transform with op1 resolved');
-          resolve();
-        });
+        }
+        return promise;
       }
-      return promise;
-    }
-  };
+    };
 
-  const queue = new ActionQueue(target);
+    const queue = new ActionQueue(target);
 
-  let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
-  let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
-  let order = 0;
+    let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
+    let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+    let order = 0;
 
-  queue.on('action', function(action) {
-    if (action.data === op1) {
-      equal(++order, 3, 'op1 completed');
-    } else if (action.data === op2) {
-      equal(++order, 6, 'op2 completed');
-    }
-  });
-
-  queue.on('complete', function() {
-    equal(++order, 7, 'queue completed');
-  });
-
-  const trigger = {};
-  Evented.extend(trigger);
-
-  queue.push('_transform', {
-    id: 1,
-    data: op1
-  });
-
-  queue.push('_transform', {
-    id: 2,
-    data: op2
-  });
-
-  queue.process()
-    .then(function() {
-      assert.equal(queue.complete, true, 'queue processing complete');
-      equal(++order, 8, 'queue resolves last');
-      done();
+    queue.on('action', function(action) {
+      if (action.data === op1) {
+        equal(++order, 3, 'op1 completed');
+      } else if (action.data === op2) {
+        equal(++order, 6, 'op2 completed');
+      }
     });
 
-  trigger.emit('start1');
-});
-
-test('will stop processing when an action errors', function(assert) {
-  assert.expect(6);
-
-  const target = {
-    _transform(op) {
-      transformCount++;
-      if (transformCount === 1) {
-        assert.strictEqual(op, op1, '_transform - op1 passed as argument');
-      } else if (transformCount === 2) {
-        throw new Error(':(');
-      }
-    }
-  };
-
-  const queue = new ActionQueue(target, { autoProcess: false });
-
-  let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
-  let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
-  let transformCount = 0;
-
-  queue.on('action', function(action) {
-    if (transformCount === 1) {
-      assert.strictEqual(action.data, op1, 'action - op1 processed');
-    } else if (transformCount === 2) {
-      assert.ok(false, 'op2 could not be processed');
-    }
-  });
-
-  queue.on('fail', function(action, err) {
-    assert.strictEqual(action.data, op2, 'fail - op2 failed processing');
-    assert.equal(err.message, ':(', 'fail - error matches expectation');
-  });
-
-  queue.on('complete', function() {
-    assert.ok(false, 'queue should not complete');
-  });
-
-  queue.push('_transform', {
-    id: 1,
-    data: op1
-  });
-
-  queue.push('_transform', {
-    id: 2,
-    data: op2
-  });
-
-  return queue.process()
-    .then(() => {
-      assert.equal(queue.complete, false, 'queue processing encountered a problem');
-      assert.equal(queue.error.message, ':(', 'process error matches expectation');
+    queue.on('complete', function() {
+      equal(++order, 7, 'queue completed');
     });
-});
 
-test('#retry resets the current action in an inactive queue and restarts processing', function(assert) {
-  assert.expect(12);
+    const trigger = {};
+    Evented.extend(trigger);
 
-  const target = {
-    _transform(op) {
-      transformCount++;
+    queue.push('_transform', {
+      id: 1,
+      data: op1
+    });
+
+    queue.push('_transform', {
+      id: 2,
+      data: op2
+    });
+
+    queue.process()
+      .then(function() {
+        assert.equal(queue.complete, true, 'queue processing complete');
+        equal(++order, 8, 'queue resolves last');
+        done();
+      });
+
+    queue.reified
+      .then(function() {
+        trigger.emit('start1');
+      });
+  });
+
+  test('will stop processing when an action errors', function(assert) {
+    assert.expect(6);
+
+    const target = {
+      _transform(op) {
+        transformCount++;
+        if (transformCount === 1) {
+          assert.strictEqual(op, op1, '_transform - op1 passed as argument');
+        } else if (transformCount === 2) {
+          throw new Error(':(');
+        }
+      }
+    };
+
+    const queue = new ActionQueue(target, { autoProcess: false });
+
+    let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
+    let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+    let transformCount = 0;
+
+    queue.on('action', function(action) {
       if (transformCount === 1) {
-        assert.strictEqual(op, op1, '_transform - op1 passed as argument');
+        assert.strictEqual(action.data, op1, 'action - op1 processed');
       } else if (transformCount === 2) {
-        throw new Error(':(');
+        assert.ok(false, 'op2 could not be processed');
+      }
+    });
+
+    queue.on('fail', function(action, err) {
+      assert.strictEqual(action.data, op2, 'fail - op2 failed processing');
+      assert.equal(err.message, ':(', 'fail - error matches expectation');
+    });
+
+    queue.on('complete', function() {
+      assert.ok(false, 'queue should not complete');
+    });
+
+    queue.push('_transform', {
+      id: 1,
+      data: op1
+    });
+
+    queue.push('_transform', {
+      id: 2,
+      data: op2
+    });
+
+    return queue.process()
+      .then(() => {
+        assert.equal(queue.complete, false, 'queue processing encountered a problem');
+        assert.equal(queue.error.message, ':(', 'process error matches expectation');
+      });
+  });
+
+  test('#retry resets the current action in an inactive queue and restarts processing', function(assert) {
+    assert.expect(12);
+
+    const target = {
+      _transform(op) {
+        transformCount++;
+        if (transformCount === 1) {
+          assert.strictEqual(op, op1, '_transform - op1 passed as argument');
+        } else if (transformCount === 2) {
+          throw new Error(':(');
+        } else if (transformCount === 3) {
+          assert.strictEqual(op, op2, '_transform - op2 passed as argument');
+        } else if (transformCount === 4) {
+          assert.strictEqual(op, op3, '_transform - op3 passed as argument');
+        }
+      }
+    };
+
+    const queue = new ActionQueue(target, { autoProcess: false });
+
+    let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
+    let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+    let op3 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+    let transformCount = 0;
+
+    queue.on('action', function(action) {
+      if (transformCount === 1) {
+        assert.strictEqual(action.data, op1, 'action - op1 processed');
       } else if (transformCount === 3) {
-        assert.strictEqual(op, op2, '_transform - op2 passed as argument');
+        assert.strictEqual(action.data, op2, 'action - op2 processed');
       } else if (transformCount === 4) {
-        assert.strictEqual(op, op3, '_transform - op3 passed as argument');
+        assert.strictEqual(action.data, op3, 'action - op3 processed');
       }
-    }
-  };
-
-  const queue = new ActionQueue(target, { autoProcess: false });
-
-  let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
-  let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
-  let op3 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
-  let transformCount = 0;
-
-  queue.on('action', function(action) {
-    if (transformCount === 1) {
-      assert.strictEqual(action.data, op1, 'action - op1 processed');
-    } else if (transformCount === 3) {
-      assert.strictEqual(action.data, op2, 'action - op2 processed');
-    } else if (transformCount === 4) {
-      assert.strictEqual(action.data, op3, 'action - op3 processed');
-    }
-  });
-
-  queue.on('fail', function(action, err) {
-    assert.strictEqual(action.data, op2, 'fail - op2 failed processing');
-    assert.equal(err.message, ':(', 'fail - error matches expectation');
-  });
-
-  queue.on('complete', function() {
-    assert.ok(true, 'queue should complete after processing has restarted');
-  });
-
-  queue.push('_transform', {
-    id: 1,
-    data: op1
-  });
-
-  queue.push('_transform', {
-    id: 2,
-    data: op2
-  });
-
-  queue.push('_transform', {
-    id: 3,
-    data: op3
-  });
-
-  return queue.process()
-    .then(() => {
-      assert.equal(queue.complete, false, 'queue processing encountered a problem');
-      assert.equal(queue.error.message, ':(', 'process error matches expectation');
-      assert.strictEqual(queue.current.data, op2, 'op2 is current failed action');
-
-      // skip current action and continue processing
-      return queue.retry();
     });
-});
 
-test('#skip removes the current action from an inactive queue and restarts processing', function(assert) {
-  assert.expect(8);
-
-  const target = {
-    _transform(op) {
-      transformCount++;
-      if (transformCount === 1) {
-        assert.strictEqual(op, op1, '_transform - op1 passed as argument');
-      } else if (transformCount === 2) {
-        throw new Error(':(');
-      } else if (transformCount === 3) {
-        assert.strictEqual(op, op3, '_transform - op3 passed as argument');
-      }
-    }
-  };
-
-  const queue = new ActionQueue(target, { autoProcess: false });
-
-  let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
-  let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
-  let op3 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
-  let transformCount = 0;
-
-  queue.on('action', function(action) {
-    if (transformCount === 1) {
-      assert.strictEqual(action.data, op1, 'action - op1 processed');
-    } else if (transformCount === 2) {
-      assert.strictEqual(action.data, op3, 'action - op3 processed');
-    }
-  });
-
-  queue.on('fail', function(action, err) {
-    assert.strictEqual(action.data, op2, 'fail - op2 failed processing');
-    assert.equal(err.message, ':(', 'fail - error matches expectation');
-  });
-
-  queue.on('complete', function() {
-    assert.ok(true, 'queue should complete after processing has restarted');
-  });
-
-  queue.push('_transform', {
-    id: 1,
-    data: op1
-  });
-
-  queue.push('_transform', {
-    id: 2,
-    data: op2
-  });
-
-  queue.push('_transform', {
-    id: 3,
-    data: op3
-  });
-
-  return queue.process()
-    .then(() => {
-      assert.equal(queue.complete, false, 'queue processing encountered a problem');
-      assert.equal(queue.error.message, ':(', 'process error matches expectation');
-
-      // skip current action and continue processing
-      return queue.skip();
+    queue.on('fail', function(action, err) {
+      assert.strictEqual(action.data, op2, 'fail - op2 failed processing');
+      assert.equal(err.message, ':(', 'fail - error matches expectation');
     });
-});
 
-test('#shift can remove failed actions from an inactive queue, allowing processing to be restarted', function(assert) {
-  assert.expect(9);
-
-  const target = {
-    _transform(op) {
-      transformCount++;
-      if (transformCount === 1) {
-        assert.strictEqual(op, op1, '_transform - op1 passed as argument');
-      } else if (transformCount === 2) {
-        throw new Error(':(');
-      } else if (transformCount === 3) {
-        assert.strictEqual(op, op3, '_transform - op3 passed as argument');
-      }
-    }
-  };
-
-  const queue = new ActionQueue(target, { autoProcess: false });
-
-  let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
-  let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
-  let op3 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
-  let transformCount = 0;
-
-  queue.on('action', function(action) {
-    if (transformCount === 1) {
-      assert.strictEqual(action.data, op1, 'action - op1 processed');
-    } else if (transformCount === 2) {
-      assert.strictEqual(action.data, op3, 'action - op3 processed');
-    }
-  });
-
-  queue.on('fail', function(action, err) {
-    assert.strictEqual(action.data, op2, 'fail - op2 failed processing');
-    assert.equal(err.message, ':(', 'fail - error matches expectation');
-  });
-
-  queue.on('complete', function() {
-    assert.ok(true, 'queue should complete after processing has restarted');
-  });
-
-  queue.push('_transform', {
-    id: 1,
-    data: op1
-  });
-
-  queue.push('_transform', {
-    id: 2,
-    data: op2
-  });
-
-  queue.push('_transform', {
-    id: 3,
-    data: op3
-  });
-
-  return queue.process()
-    .then(() => {
-      assert.equal(queue.complete, false, 'queue processing encountered a problem');
-      assert.equal(queue.error.message, ':(', 'process error matches expectation');
-
-      let failedAction = queue.shift();
-      assert.strictEqual(failedAction.data, op2, 'op2, which failed, is returned from `shift`');
-
-      // continue processing
-      return queue.process();
+    queue.on('complete', function() {
+      assert.ok(true, 'queue should complete after processing has restarted');
     });
-});
 
-test('#unshift can add a new action to the beginning of an inactive queue', function(assert) {
-  assert.expect(5);
-  const done = assert.async();
+    queue.push('_transform', {
+      id: 1,
+      data: op1
+    });
 
-  const target = {
-    _transform(op) {
-      transformCount++;
-      if (transformCount === 1) {
-        assert.strictEqual(op, op2, '_transform - op2 passed as argument');
-      } else if (transformCount === 2) {
-        assert.strictEqual(op, op1, '_transform - op1 passed as argument');
+    queue.push('_transform', {
+      id: 2,
+      data: op2
+    });
+
+    queue.push('_transform', {
+      id: 3,
+      data: op3
+    });
+
+    return queue.process()
+      .then(() => {
+        assert.equal(queue.complete, false, 'queue processing encountered a problem');
+        assert.equal(queue.error.message, ':(', 'process error matches expectation');
+        assert.strictEqual(queue.current.data, op2, 'op2 is current failed action');
+
+        // skip current action and continue processing
+        return queue.retry();
+      });
+  });
+
+  test('#skip removes the current action from an inactive queue and restarts processing', function(assert) {
+    assert.expect(8);
+
+    const target = {
+      _transform(op) {
+        transformCount++;
+        if (transformCount === 1) {
+          assert.strictEqual(op, op1, '_transform - op1 passed as argument');
+        } else if (transformCount === 2) {
+          throw new Error(':(');
+        } else if (transformCount === 3) {
+          assert.strictEqual(op, op3, '_transform - op3 passed as argument');
+        }
       }
-    }
-  };
+    };
 
-  const queue = new ActionQueue(target, { autoProcess: false });
+    const queue = new ActionQueue(target, { autoProcess: false });
 
-  let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
-  let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
-  let transformCount = 0;
+    let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
+    let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+    let op3 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+    let transformCount = 0;
 
-  queue.on('action', function(action) {
-    if (transformCount === 1) {
-      assert.strictEqual(action.data, op2, 'op2 processed');
-    } else if (transformCount === 2) {
-      assert.strictEqual(action.data, op1, 'op1 processed');
-    }
+    queue.on('action', function(action) {
+      if (transformCount === 1) {
+        assert.strictEqual(action.data, op1, 'action - op1 processed');
+      } else if (transformCount === 2) {
+        assert.strictEqual(action.data, op3, 'action - op3 processed');
+      }
+    });
+
+    queue.on('fail', function(action, err) {
+      assert.strictEqual(action.data, op2, 'fail - op2 failed processing');
+      assert.equal(err.message, ':(', 'fail - error matches expectation');
+    });
+
+    queue.on('complete', function() {
+      assert.ok(true, 'queue should complete after processing has restarted');
+    });
+
+    queue.push('_transform', {
+      id: 1,
+      data: op1
+    });
+
+    queue.push('_transform', {
+      id: 2,
+      data: op2
+    });
+
+    queue.push('_transform', {
+      id: 3,
+      data: op3
+    });
+
+    return queue.process()
+      .then(() => {
+        assert.equal(queue.complete, false, 'queue processing encountered a problem');
+        assert.equal(queue.error.message, ':(', 'process error matches expectation');
+
+        // skip current action and continue processing
+        return queue.skip();
+      });
   });
 
-  queue.on('complete', function() {
-    assert.ok(true, 'queue completed');
-    done();
+  test('#shift can remove failed actions from an inactive queue, allowing processing to be restarted', function(assert) {
+    assert.expect(9);
+
+    const target = {
+      _transform(op) {
+        transformCount++;
+        if (transformCount === 1) {
+          assert.strictEqual(op, op1, '_transform - op1 passed as argument');
+        } else if (transformCount === 2) {
+          throw new Error(':(');
+        } else if (transformCount === 3) {
+          assert.strictEqual(op, op3, '_transform - op3 passed as argument');
+        }
+      }
+    };
+
+    const queue = new ActionQueue(target, { autoProcess: false });
+
+    let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
+    let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+    let op3 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+    let transformCount = 0;
+
+    queue.on('action', function(action) {
+      if (transformCount === 1) {
+        assert.strictEqual(action.data, op1, 'action - op1 processed');
+      } else if (transformCount === 2) {
+        assert.strictEqual(action.data, op3, 'action - op3 processed');
+      }
+    });
+
+    queue.on('fail', function(action, err) {
+      assert.strictEqual(action.data, op2, 'fail - op2 failed processing');
+      assert.equal(err.message, ':(', 'fail - error matches expectation');
+    });
+
+    queue.on('complete', function() {
+      assert.ok(true, 'queue should complete after processing has restarted');
+    });
+
+    queue.push('_transform', {
+      id: 1,
+      data: op1
+    });
+
+    queue.push('_transform', {
+      id: 2,
+      data: op2
+    });
+
+    queue.push('_transform', {
+      id: 3,
+      data: op3
+    });
+
+    return queue.process()
+      .then(() => {
+        assert.equal(queue.complete, false, 'queue processing encountered a problem');
+        assert.equal(queue.error.message, ':(', 'process error matches expectation');
+
+        return queue.shift()
+          .then(failedAction => {
+            assert.strictEqual(failedAction.data, op2, 'op2, which failed, is returned from `shift`');
+          })
+          .then(function() {
+            // continue processing
+            return queue.process();
+          });
+      });
   });
 
-  queue.push('_transform', {
-    id: 1,
-    data: op1
-  });
+  test('#unshift can add a new action to the beginning of an inactive queue', function(assert) {
+    assert.expect(5);
+    const done = assert.async();
 
-  queue.unshift('_transform', {
-    id: 2,
-    data: op2
-  });
+    const target = {
+      _transform(op) {
+        transformCount++;
+        if (transformCount === 1) {
+          assert.strictEqual(op, op2, '_transform - op2 passed as argument');
+        } else if (transformCount === 2) {
+          assert.strictEqual(op, op1, '_transform - op1 passed as argument');
+        }
+      }
+    };
 
-  queue.process();
-});
+    const queue = new ActionQueue(target, { autoProcess: false });
 
-test('#clear removes all actions from an inactive queue', function(assert) {
-  assert.expect(2);
-  const done = assert.async();
+    let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
+    let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+    let transformCount = 0;
 
-  const target = {
-    _transform() {
-      assert.ok(false, '_transform should not be called');
-    }
-  };
+    queue.on('action', function(action) {
+      if (transformCount === 1) {
+        assert.strictEqual(action.data, op2, 'op2 processed');
+      } else if (transformCount === 2) {
+        assert.strictEqual(action.data, op1, 'op1 processed');
+      }
+    });
 
-  const queue = new ActionQueue(target, { autoProcess: false });
-
-  let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
-  let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
-
-  queue.on('action', function() {
-    assert.ok(false, 'no actions should be processed');
-  });
-
-  queue.on('complete', function() {
-    assert.ok(true, 'queue completed after clear');
-  });
-
-  queue.push('_transform', {
-    id: 1,
-    data: op1
-  });
-
-  queue.unshift('_transform', {
-    id: 2,
-    data: op2
-  });
-
-  queue.clear()
-    .then(() => {
-      assert.ok(true, 'queue was cleared');
+    queue.on('complete', function() {
+      assert.ok(true, 'queue completed');
       done();
     });
+
+    queue.push('_transform', {
+      id: 1,
+      data: op1
+    });
+
+    queue.unshift('_transform', {
+      id: 2,
+      data: op2
+    });
+
+    queue.process();
+  });
+
+  test('#clear removes all actions from an inactive queue', function(assert) {
+    assert.expect(2);
+    const done = assert.async();
+
+    const target = {
+      _transform() {
+        assert.ok(false, '_transform should not be called');
+      }
+    };
+
+    const queue = new ActionQueue(target, { autoProcess: false });
+
+    let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
+    let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+
+    queue.on('action', function() {
+      assert.ok(false, 'no actions should be processed');
+    });
+
+    queue.on('complete', function() {
+      assert.ok(true, 'queue completed after clear');
+    });
+
+    queue.push('_transform', {
+      id: 1,
+      data: op1
+    });
+
+    queue.unshift('_transform', {
+      id: 2,
+      data: op2
+    });
+
+    queue.clear()
+      .then(() => {
+        assert.ok(true, 'queue was cleared');
+        done();
+      });
+  });
+
+  module('assigned a bucket', function(assert) {
+    const op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
+    const op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+
+    let bucket;
+
+    assert.beforeEach(function() {
+      bucket = new FakeBucket();
+    });
+
+    assert.afterEach(function() {
+      bucket = null;
+    });
+
+    test('will be reified with the actions serialized in its bucket and immediately process them', function(assert) {
+      const done = assert.async();
+      assert.expect(3);
+
+      const target = {
+        _transform() {}
+      };
+
+      const serialized = [
+        {
+          method: '_transform',
+          data: op1,
+          meta: { label: 'one' }
+        },
+        {
+          method: '_transform',
+          data: op2,
+          meta: { label: 'two' }
+        }
+      ];
+
+      let queue;
+      bucket.setItem('queue', serialized)
+        .then(() => {
+          queue = new ActionQueue(target, { bucket, name: 'queue' });
+          return queue.reified;
+        })
+        .then(() => {
+          assert.equal(queue.length, 2, 'queue has two actions');
+
+          queue.on('complete', function() {
+            assert.ok(true, 'queue completed');
+
+            bucket.getItem('queue')
+              .then(serialized => {
+                assert.deepEqual(serialized, [], 'no serialized ops remain');
+                done();
+              });
+          });
+        });
+    });
+
+    test('#push - actions pushed to a queue are persisted to its bucket', function(assert) {
+      const done = assert.async();
+      assert.expect(6);
+
+      const target = {
+        _transform() {}
+      };
+
+      const queue = new ActionQueue(target, { bucket, name: 'queue' });
+
+      let transformCount = 0;
+
+      queue.on('beforeAction', function(action) {
+        transformCount++;
+
+        if (transformCount === 1) {
+          assert.strictEqual(action.data, op1, 'op1 processed');
+          bucket.getItem('queue')
+            .then(serialized => {
+              assert.deepEqual(serialized, [
+                {
+                  method: '_transform',
+                  data: op1,
+                  meta: { label: 'one' }
+                },
+                {
+                  method: '_transform',
+                  data: op2,
+                  meta: { label: 'two' }
+                }
+              ], 'two ops have been serialized');
+            });
+        } else if (transformCount === 2) {
+          assert.strictEqual(action.data, op2, 'op2 processed');
+          bucket.getItem('queue')
+            .then(serialized => {
+              assert.deepEqual(serialized, [
+                {
+                  method: '_transform',
+                  data: op2,
+                  meta: { label: 'two' }
+                }
+              ], 'one serialized op remains');
+            });
+        }
+      });
+
+      queue.on('complete', function() {
+        assert.ok(true, 'queue completed');
+
+        bucket.getItem('queue')
+          .then(serialized => {
+            assert.deepEqual(serialized, [], 'no serialized ops remain');
+            done();
+          });
+      });
+
+      queue.push('_transform', { data: op1, meta: { label: 'one' } });
+      queue.push('_transform', { data: op2, meta: { label: 'two' } });
+    });
+  });
 });

--- a/test/tests/unit/action-test.js
+++ b/test/tests/unit/action-test.js
@@ -11,23 +11,30 @@ test('can be instantiated', function(assert) {
   assert.ok(action);
 });
 
-test('can be assigned an optional id and data', function(assert) {
-  const action = new Action({ id: 'abc', data: '123' });
-  assert.equal(action.id, 'abc', 'id has been set');
-  assert.equal(action.data, '123', 'data has been set');
+test('can be assigned optional data and meta', function(assert) {
+  const target = {
+    doSomething() {}
+  };
+  const action = new Action(target, 'doSomething', { data: 'abc', meta: { label: '123' } });
+  assert.deepEqual(action.data, 'abc', 'data has been set');
+  assert.deepEqual(action.meta, { label: '123' }, 'meta has been set');
 });
 
 test('can be assigned a synchronous function to process', function(assert) {
   assert.expect(5);
 
-  const action = new Action({
-    process() {
+  let action;
+
+  const target = {
+    doSomething() {
       assert.ok(true, 'process invoked');
-      assert.ok(this.started, 'action started');
-      assert.ok(!this.settled, 'action not settled');
+      assert.ok(action.started, 'action started');
+      assert.ok(!action.settled, 'action not settled');
       return ':)';
     }
-  });
+  };
+
+  action = new Action(target, 'doSomething');
 
   return action.process()
     .then(function(response) {
@@ -39,11 +46,13 @@ test('can be assigned a synchronous function to process', function(assert) {
 test('can be assigned an asynchronous function to process', function(assert) {
   assert.expect(5);
 
-  const action = new Action({
-    process: function() {
+  let action;
+
+  const target = {
+    doSomething() {
       assert.ok(true, 'process invoked');
-      assert.ok(this.started, 'action started');
-      assert.ok(!this.settled, 'action not settled');
+      assert.ok(action.started, 'action started');
+      assert.ok(!action.settled, 'action not settled');
       return new Promise(function(resolve) {
         function respond() {
           resolve(':)');
@@ -51,7 +60,9 @@ test('can be assigned an asynchronous function to process', function(assert) {
         setTimeout(respond, 1);
       });
     }
-  });
+  };
+
+  action = new Action(target, 'doSomething');
 
   return action.process()
     .then(function(response) {
@@ -63,12 +74,16 @@ test('can be assigned an asynchronous function to process', function(assert) {
 test('can be assigned a synchronous function that throws an exception', function(assert) {
   assert.expect(2);
 
-  const action = new Action({
-    process: function() {
+  let action;
+
+  const target = {
+    doSomething() {
       assert.ok(true, 'process invoked');
       throw new Error(':(');
     }
-  });
+  };
+
+  action = new Action(target, 'doSomething');
 
   return action.process()
     .catch((e) => {
@@ -77,18 +92,23 @@ test('can be assigned a synchronous function that throws an exception', function
 });
 
 test('can be assigned an asynchronous function that rejects', function(assert) {
-  assert.expect(5);
+  assert.expect(6);
 
-  const action = new Action({
-    process: function() {
+  let action;
+
+  const target = {
+    doSomething(data) {
       assert.ok(true, 'process invoked');
-      assert.ok(this.started, 'action started');
-      assert.ok(!this.settled, 'action not settled');
+      assert.equal(data, '1', 'argument matches');
+      assert.ok(action.started, 'action started');
+      assert.ok(!action.settled, 'action not settled');
       return new Promise(function(resolve, reject) {
         setTimeout(reject(':('), 1);
       });
     }
-  });
+  };
+
+  action = new Action(target, 'doSomething', { data: '1' });
 
   return action.process()
     .catch((e) => {
@@ -98,14 +118,19 @@ test('can be assigned an asynchronous function that rejects', function(assert) {
 });
 
 test('it creates a promise immediately that won\'t be resolved until process is called', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
-  var action = new Action({
-    process() {
+  let action;
+
+  const target = {
+    doSomething(data) {
       assert.ok(true, 'process invoked');
+      assert.equal(data, '1', 'argument matches');
       return;
     }
-  });
+  };
+
+  action = new Action(target, 'doSomething', { data: '1' });
 
   action.settle()
     .then(function() {
@@ -118,14 +143,18 @@ test('it creates a promise immediately that won\'t be resolved until process is 
 test('#reset returns to an unstarted, unsettled state', function(assert) {
   assert.expect(7);
 
-  const action = new Action({
-    process() {
+  let action;
+
+  const target = {
+    doSomething() {
       assert.ok(true, 'process invoked');
-      assert.ok(this.started, 'action started');
-      assert.ok(!this.settled, 'action not settled');
+      assert.ok(action.started, 'action started');
+      assert.ok(!action.settled, 'action not settled');
       return ':)';
     }
-  });
+  };
+
+  action = new Action(target, 'doSomething');
 
   return action.process()
     .then(function(response) {
@@ -137,14 +166,4 @@ test('#reset returns to an unstarted, unsettled state', function(assert) {
       assert.ok(!action.started, 'after reset, action has not started');
       assert.ok(!action.settled, 'after reset, action has not settled');
     });
-});
-
-test('Action.from will return an action instance passed into it', function(assert) {
-  let action = new Action({process: function() {}});
-  assert.strictEqual(Action.from(action), action);
-});
-
-test('Action.from will create an action from options passed into it', function(assert) {
-  let action = Action.from({process: function() {}});
-  assert.ok(action instanceof Action);
 });

--- a/test/tests/unit/action-test.js
+++ b/test/tests/unit/action-test.js
@@ -20,6 +20,34 @@ test('can be assigned optional data and meta', function(assert) {
   assert.deepEqual(action.meta, { label: '123' }, 'meta has been set');
 });
 
+test('can be serialized', function(assert) {
+  const target = {
+    doSomething() {}
+  };
+  const action = new Action(target, 'doSomething', { data: 'abc', meta: { label: '123' } });
+  assert.deepEqual(
+    action.serialize(),
+    {
+      method: 'doSomething',
+      data: 'abc',
+      meta: { label: '123' }
+    }
+  );
+});
+
+test('can be deserialized', function(assert) {
+  const target = {
+    doSomething() {}
+  };
+  const action = Action.deserialize(target, {
+    method: 'doSomething',
+    data: 'abc',
+    meta: { label: '123' }
+  });
+  assert.deepEqual(action.data, 'abc', 'data has been set');
+  assert.deepEqual(action.meta, { label: '123' }, 'meta has been set');
+});
+
 test('can be assigned a synchronous function to process', function(assert) {
   assert.expect(5);
 

--- a/test/tests/unit/coordinator-test.js
+++ b/test/tests/unit/coordinator-test.js
@@ -27,6 +27,11 @@ module('Orbit - Coordinator', function(hooks) {
   test('reviews sources and truncates their history to after the most recent common entry', function(assert) {
     assert.expect(14);
 
+    coordinator = new Coordinator({
+      sources: [s1, s2, s3],
+      autoActivate: false
+    });
+
     return all([
       s1._transformed([tA, tB]),
       s2._transformed([tA, tB]),
@@ -42,10 +47,8 @@ module('Orbit - Coordinator', function(hooks) {
 
       assert.ok(s3.transformLog.contains('b'), 's3 contains c');
 
-      coordinator = new Coordinator({
-        sources: [s1, s2, s3]
-      });
-
+      return coordinator.review();
+    }).then(() => {
       assert.ok(!s1.transformLog.contains('a'), 's1 has removed a');
       assert.ok(!s2.transformLog.contains('a'), 's2 has removed a');
       assert.ok(!s3.transformLog.contains('a'), 's3 has removed a');
@@ -65,20 +68,22 @@ module('Orbit - Coordinator', function(hooks) {
       sources: [s1, s2, s3]
     });
 
-    return all([
-      s1._transformed([tA, tB]),
-      s2._transformed([tA, tB]),
-      s3._transformed([tA, tB, tC])
-    ]).then(() => {
-      assert.ok(!s1.transformLog.contains('a'), 's1 has removed a');
-      assert.ok(!s2.transformLog.contains('a'), 's2 has removed a');
-      assert.ok(!s3.transformLog.contains('a'), 's3 has removed a');
+    return coordinator.activated
+      .then(() => all([
+        s1._transformed([tA, tB]),
+        s2._transformed([tA, tB]),
+        s3._transformed([tA, tB, tC])
+      ]))
+      .then(() => {
+        assert.ok(!s1.transformLog.contains('a'), 's1 has removed a');
+        assert.ok(!s2.transformLog.contains('a'), 's2 has removed a');
+        assert.ok(!s3.transformLog.contains('a'), 's3 has removed a');
 
-      assert.ok(!s1.transformLog.contains('b'), 's1 has removed b');
-      assert.ok(!s2.transformLog.contains('b'), 's2 has removed b');
-      assert.ok(!s3.transformLog.contains('b'), 's3 has removed b');
+        assert.ok(!s1.transformLog.contains('b'), 's1 has removed b');
+        assert.ok(!s2.transformLog.contains('b'), 's2 has removed b');
+        assert.ok(!s3.transformLog.contains('b'), 's3 has removed b');
 
-      assert.ok(s3.transformLog.contains('c'), 's3 contains c');
-    });
+        assert.ok(s3.transformLog.contains('c'), 's3 contains c');
+      });
   });
 });

--- a/test/tests/unit/interfaces/pullable-test.js
+++ b/test/tests/unit/interfaces/pullable-test.js
@@ -9,7 +9,7 @@ let source;
 
 module('Orbit - Source Interfaces - Pullable', {
   setup: function() {
-    source = new Source();
+    source = new Source({ name: 'src1' });
     Pullable.extend(source);
   },
 

--- a/test/tests/unit/interfaces/pushable-test.js
+++ b/test/tests/unit/interfaces/pushable-test.js
@@ -8,7 +8,7 @@ let source;
 
 module('Orbit - Pushable', {
   setup: function() {
-    source = new Source();
+    source = new Source({ name: 'src1' });
     Pushable.extend(source);
   },
 

--- a/test/tests/unit/interfaces/queryable-test.js
+++ b/test/tests/unit/interfaces/queryable-test.js
@@ -7,7 +7,7 @@ let source;
 
 module('Orbit - Queryable', {
   setup: function() {
-    source = new Source();
+    source = new Source({ name: 'src1' });
     Queryable.extend(source);
   },
 

--- a/test/tests/unit/interfaces/syncable-test.js
+++ b/test/tests/unit/interfaces/syncable-test.js
@@ -7,7 +7,7 @@ let source;
 
 module('Orbit - Syncable', {
   setup() {
-    source = new Source();
+    source = new Source({ name: 'src1' });
     Syncable.extend(source);
   },
 

--- a/test/tests/unit/interfaces/updatable-test.js
+++ b/test/tests/unit/interfaces/updatable-test.js
@@ -8,7 +8,7 @@ let source;
 
 module('Orbit - Updatable', {
   setup: function() {
-    source = new Source();
+    source = new Source({ name: 'src1' });
     Updatable.extend(source);
   },
 

--- a/test/tests/unit/source-test.js
+++ b/test/tests/unit/source-test.js
@@ -1,27 +1,49 @@
 import Source from 'orbit/source';
 import Transform from 'orbit/transform';
+import { FakeBucket } from 'tests/test-helper';
 
-module('Orbit - Source', function(hooks) {
+module('Orbit - Source', function() {
   let source;
 
-  hooks.beforeEach(function() {
-    source = new Source();
-  });
-
-  test('it exists', function(assert) {
+  test('it can be instantiated', function(assert) {
+    source = new Source({ name: 'src1' });
     assert.ok(source);
     assert.ok(source.transformLog, 'has a transform log');
   });
 
+  test('it requires a name', function(assert) {
+    assert.throws(function() {
+      source = new Source();
+    },
+    Error('Assertion failed: Source requires a name'),
+    'assertion raised');
+  });
+
   test('it should mixin Evented', function(assert) {
+    source = new Source({ name: 'src1' });
     ['on', 'off', 'emit'].forEach(function(prop) {
       assert.ok(source[prop], 'should have Evented properties');
     });
   });
 
+  test('creates a `transformLog`, `requestQueue`, and `syncQueue`, and assigns each the same bucket as the Source', function(assert) {
+    assert.expect(8);
+    const bucket = new FakeBucket();
+    source = new Source({ name: 'src1', bucket });
+    assert.equal(source.name, 'src1', 'source has been assigned name');
+    assert.equal(source.transformLog.name, 'src1-log', 'transformLog has been assigned name');
+    assert.equal(source.requestQueue.name, 'src1-requests', 'requestQueue has been assigned name');
+    assert.equal(source.syncQueue.name, 'src1-sync', 'syncQueue has been assigned name');
+    assert.strictEqual(source.bucket, bucket, 'source has been assigned bucket');
+    assert.strictEqual(source.transformLog.bucket, bucket, 'transformLog has been assigned bucket');
+    assert.strictEqual(source.requestQueue.bucket, bucket, 'requestQueue has been assigned bucket');
+    assert.strictEqual(source.syncQueue.bucket, bucket, 'syncQueue has been assigned bucket');
+  });
+
   test('#_transformed should trigger `transform` event BEFORE resolving', function(assert) {
     assert.expect(3);
 
+    source = new Source({ name: 'src1' });
     let order = 0;
     const appliedTransform = Transform.from({ op: 'addRecord', value: {} });
 
@@ -39,6 +61,7 @@ module('Orbit - Source', function(hooks) {
   test('#transformLog contains transforms applied', function(assert) {
     assert.expect(2);
 
+    source = new Source({ name: 'src1' });
     const appliedTransform = Transform.from({ op: 'addRecord', value: {} });
 
     assert.ok(!source.transformLog.contains(appliedTransform.id));

--- a/test/tests/unit/transform-log-test.js
+++ b/test/tests/unit/transform-log-test.js
@@ -1,6 +1,7 @@
 /* globals Immutable */
 import TransformLog from 'orbit/transform/log';
 import { TransformNotLoggedException, OutOfRangeException } from 'orbit/lib/exceptions';
+import { FakeBucket } from 'tests/test-helper';
 
 module('Orbit - TransformLog', function() {
   const transformAId = 'f8d2c75f-f758-4314-b5c5-ac7fb783ab26';
@@ -40,13 +41,15 @@ module('Orbit - TransformLog', function() {
     test('#append', function(assert) {
       assert.expect(3);
 
-      log.on('append', (transformId, data) => {
-        assert.strictEqual(transformId, transformAId, 'append event emits transform');
+      log.on('append', (transformIds, data) => {
+        assert.deepEqual(transformIds, [transformAId], 'append event emits transform');
         assert.strictEqual(data.size, 0, 'append event emits prev state');
       });
 
-      log.append(transformAId);
-      assert.deepEqual(log.entries, [transformAId], 'adds transformId to log');
+      return log.append(transformAId)
+        .then(() => {
+          assert.deepEqual(log.entries, [transformAId], 'adds transformId to log');
+        });
     });
 
     test('#head', function(assert) {
@@ -58,9 +61,11 @@ module('Orbit - TransformLog', function() {
     assert.beforeEach(function() {
       log = new TransformLog();
 
-      log.append(transformAId);
-      log.append(transformBId);
-      log.append(transformCId);
+      return log.append(
+        transformAId,
+        transformBId,
+        transformCId
+      );
     });
 
     test('#data', function(assert) {
@@ -128,8 +133,10 @@ module('Orbit - TransformLog', function() {
         assert.strictEqual(data.size, 3, 'clear event emits prev state');
       });
 
-      log.clear();
-      assert.deepEqual(log.entries, [], 'clears all transforms');
+      return log.clear()
+        .then(() => {
+          assert.deepEqual(log.entries, [], 'clears all transforms');
+        });
     });
 
     test('#truncate', function(assert) {
@@ -141,30 +148,45 @@ module('Orbit - TransformLog', function() {
         assert.strictEqual(data.size, 3, 'truncate event emits prev state');
       });
 
-      log.truncate(transformBId);
-      assert.deepEqual(log.entries, [transformBId, transformCId], 'removes transformIds before specified transformId');
+      return log.truncate(transformBId)
+        .then(() => {
+          assert.deepEqual(log.entries, [transformBId, transformCId], 'removes transformIds before specified transformId');
+        });
     });
 
     test('#truncate - to head', function(assert) {
-      log.truncate(log.head);
-      assert.deepEqual(log.entries, [transformCId], 'only head entry remains in log');
+      return log.truncate(log.head)
+        .then(() => {
+          assert.deepEqual(log.entries, [transformCId], 'only head entry remains in log');
+        });
     });
 
     test('#truncate - just past head clears the log', function(assert) {
-      log.truncate(transformCId, +1);
-      assert.deepEqual(log.entries, [], 'clears log');
+      return log.truncate(transformCId, +1)
+        .then(() => {
+          assert.deepEqual(log.entries, [], 'clears log');
+        });
     });
 
     test('#truncate - to transformId that hasn\'t been logged', function(assert) {
-      assert.throws(() => log.truncate(transformDId), TransformNotLoggedException);
+      return log.truncate(transformDId)
+        .catch(e => {
+          assert.ok(e instanceof TransformNotLoggedException, 'TransformNotLoggedException caught');
+        });
     });
 
     test('#truncate - specifying a relativePosition that is too low', function(assert) {
-      assert.throws(() => log.truncate(transformAId, -1), OutOfRangeException);
+      return log.truncate(transformAId, -1)
+        .catch(e => {
+          assert.ok(e instanceof OutOfRangeException, 'OutOfRangeException caught');
+        });
     });
 
     test('#truncate - specifying a relativePosition that is too high', function(assert) {
-      assert.throws(() => log.truncate(transformCId, +2), OutOfRangeException);
+      return log.truncate(transformCId, +2)
+        .catch(e => {
+          assert.ok(e instanceof OutOfRangeException, 'OutOfRangeException caught');
+        });
     });
 
     test('#rollback', function(assert) {
@@ -176,32 +198,46 @@ module('Orbit - TransformLog', function() {
         assert.strictEqual(data.size, 3, 'rollback event emits prev state');
       });
 
-      log.rollback(transformAId);
-      assert.deepEqual(log.entries, [transformAId], 'removes transformIds after specified transformId');
+      return log.rollback(transformAId)
+        .then(() => {
+          assert.deepEqual(log.entries, [transformAId], 'removes transformIds after specified transformId');
+        });
     });
 
     test('#rollback - to head', function(assert) {
-      log.rollback(log.head);
-      assert.deepEqual(log.head, transformCId, 'doesn\'t change log');
+      return log.rollback(log.head)
+        .then(() => {
+          assert.deepEqual(log.head, transformCId, 'doesn\'t change log');
+        });
     });
 
     test('#rollback - to transformId that hasn\'t been logged', function(assert) {
-      assert.throws(() => log.rollback(transformDId), TransformNotLoggedException);
+      return log.rollback(transformDId)
+        .catch(e => {
+          assert.ok(e instanceof TransformNotLoggedException, 'TransformNotLoggedException caught');
+        });
     });
 
     test('#rollback - to just before first', function(assert) {
-      log.rollback(transformAId, -1);
-      assert.deepEqual(log.entries, [], 'removes all entries');
+      return log.rollback(transformAId, -1)
+        .then(() => {
+          assert.deepEqual(log.entries, [], 'removes all entries');
+        });
     });
 
     test('#rollback - specifying a relativePosition that is too low', function(assert) {
-      assert.throws(() => log.rollback(transformAId, -2), OutOfRangeException);
+      return log.rollback(transformAId, -2)
+        .catch(e => {
+          assert.ok(e instanceof OutOfRangeException, 'OutOfRangeException caught');
+        });
     });
 
     test('#rollback - specifying a relativePosition that is too high', function(assert) {
-      assert.throws(() => log.rollback(transformCId, +1), OutOfRangeException);
+      return log.rollback(transformCId, +1)
+        .catch(e => {
+          assert.ok(e instanceof OutOfRangeException, 'OutOfRangeException caught');
+        });
     });
-
 
     test('#head', function(assert) {
       assert.equal(log.head, transformCId, 'is last transformId');
@@ -209,6 +245,89 @@ module('Orbit - TransformLog', function() {
 
     test('#contains', function(assert) {
       assert.ok(log.contains(transformAId), 'identifies when log contains a transform');
+    });
+  });
+
+  module('using a bucket', function(assert) {
+    let bucket;
+
+    assert.beforeEach(function() {
+      bucket = new FakeBucket();
+    });
+
+    assert.afterEach(function() {
+      bucket = null;
+    });
+
+    test('will be reified from data in the bucket', function(assert) {
+      assert.expect(1);
+      return bucket.setItem('log', [transformAId, transformBId])
+        .then(() => {
+          log = new TransformLog(null, { bucket, name: 'log' });
+          return log.reified;
+        })
+        .then(() => {
+          assert.equal(log.data.size, 2, 'log contains the expected transforms');
+        });
+    });
+
+    test('#append - changes appended to the log are persisted to its bucket', function(assert) {
+      assert.expect(2);
+      log = new TransformLog(null, { bucket, name: 'log' });
+
+      return log.append(transformAId, transformBId)
+        .then(() => {
+          assert.equal(log.length, 2, 'log contains the expected transforms');
+          return bucket.getItem('log');
+        })
+        .then(logged => {
+          assert.deepEqual(logged, [transformAId, transformBId], 'bucket contains the expected transforms');
+        });
+    });
+
+    test('#truncate - truncations to the log are persisted to its bucket', function(assert) {
+      assert.expect(2);
+      log = new TransformLog(null, { bucket, name: 'log' });
+
+      return log.append(transformAId, transformBId, transformCId)
+        .then(() => log.truncate(log.head))
+        .then(() => {
+          assert.equal(log.data.size, 1, 'log contains the expected transforms');
+          return bucket.getItem('log');
+        })
+        .then(logged => {
+          assert.deepEqual(logged, [transformCId], 'bucket contains the expected transforms');
+        });
+    });
+
+    test('#rollback - when the log is rolled back, it is persisted to its bucket', function(assert) {
+      assert.expect(2);
+      log = new TransformLog(null, { bucket, name: 'log' });
+
+      return log.append(transformAId, transformBId, transformCId)
+        .then(() => log.rollback(transformBId))
+        .then(() => {
+          assert.equal(log.data.size, 2, 'log contains the expected transforms');
+          return bucket.getItem('log');
+        })
+        .then(logged => {
+          assert.deepEqual(logged, [transformAId, transformBId], 'bucket contains the expected transforms');
+        });
+    });
+
+    test('#clear - when the log is cleared, it is persisted to its bucket', function(assert) {
+      assert.expect(2);
+      log = new TransformLog(null, { bucket, name: 'log' });
+
+      return log.append(transformAId, transformBId, transformCId)
+        .then(() => log.clear())
+        .then(() => {
+          assert.equal(log.data.size, 0, 'log contains the expected transforms');
+          return bucket.getItem('log');
+        })
+        .then(logged => {
+          assert.deepEqual(logged, [], 'bucket contains the expected transforms');
+        });
     });
   });
 });


### PR DESCRIPTION
Allow sources to persist their transient, in-memory state to a simple browser storage mechanism.

To be truly useful, this will require actual bucket implementations in orbit-local-storage and orbit-indexeddb.