### PR TITLE
Disallow lazy evaluation of schemas in favor of explicit schema upgrades.

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -289,27 +289,21 @@ export default class Schema {
     // register provided model schema
     this.models = {};
     if (options.models) {
-      for (var modelName in options.models) {
-        if (options.models.hasOwnProperty(modelName)) {
-          this.registerModel(modelName, options.models[modelName]);
-        }
-      }
+      Object.keys(options.models).forEach(modelName => {
+        this._registerModel(modelName, options.models[modelName]);
+      });
     }
   }
 
   /**
    Registers a model's schema definition.
 
-   Emits the `modelRegistered` event upon completion.
-
    @param {String} [name]       name of the model
    @param {Object} [definition] model schema definition
+   @private
    */
-  registerModel(name, definition) {
-    var modelSchema = this._mergeModelSchemas({}, this.modelDefaults, definition);
-
-    this.models[name] = modelSchema;
-    this.emit('modelRegistered', name);
+  _registerModel(name, definition) {
+    this.models[name] = this._mergeModelSchemas({}, this.modelDefaults, definition);
   }
 
   /**
@@ -335,24 +329,9 @@ export default class Schema {
   }
 
   /**
-   A hook that can be used to define a model that's not yet defined.
-
-   This allows for schemas to lazily define models, rather than requiring
-   full definitions upfront.
-
-   @method modelNotDefined
-   @param {String} [model] name of model
-   */
-  modelNotDefined() {}
-
-  /**
    Look up a model definition.
 
-   If none can be found, `modelNotDefined` will be triggered, which provides
-   an opportunity for lazily defining models.
-
-   If still no model has been defined, a `ModelNotRegisteredException` is
-   raised.
+   If no model has been defined, a `ModelNotRegisteredException` is raised.
 
    @method modelDefinition
    @param {String} type - type of model
@@ -362,14 +341,7 @@ export default class Schema {
     let definition = this.models[type];
 
     if (!definition) {
-      // Call a hook for lazy type definition
-      this.modelNotDefined(type);
-
-      definition = this.models[type];
-
-      if (!definition) {
-        throw new ModelNotRegisteredException(type);
-      }
+      throw new ModelNotRegisteredException(type);
     }
 
     return definition;
@@ -496,10 +468,6 @@ export default class Schema {
     if (!relDef) { throw new RelationshipNotRegisteredException(modelName, relationship); }
 
     return relDef;
-  }
-
-  ensureModelTypeInitialized(type) {
-    this.modelDefinition(type);
   }
 
   _mergeModelSchemas(base) {

--- a/src/schema.js
+++ b/src/schema.js
@@ -14,7 +14,7 @@ import Evented from './evented';
  attributes and relationships. A single schema may be shared across multiple
  sources.
 
- Schemas are defined with an initial set of options, passed in as a constructor
+ Schemas are defined with an initial set of settings, passed in as a constructor
  argument:
 
  ``` javascript
@@ -257,66 +257,106 @@ follows:
  ```
 
  @class Schema
- @namespace OC
- @param {Object}   [options]
- @param {Object}   [options.modelDefaults] defaults for model schemas
- @param {Function} [options.pluralize] Function used to pluralize names
- @param {Function} [options.singularize] Function used to singularize names
- @param {Object}   [options.models] schemas for individual models supported by this schema
- @constructor
  */
 export default class Schema {
-  constructor(_options) {
-    let options = _options || {};
+  /**
+   * Create a new Schema.
+   *
+   * @constructor
+   * @param {Object}   [settings={}]
+   * @param {Integer}  [settings.version]       Optional. Schema version. Defaults to 1.
+   * @param {Object}   [settings.models]        Schemas for individual models supported by this schema.
+   * @param {Object}   [settings.modelDefaults] Optional. Defaults for model schemas.
+   * @param {Function} [settings.pluralize]     Optional. Function used to pluralize names.
+   * @param {Function} [settings.singularize]   Optional. Function used to singularize names.
+   */
+  constructor(settings = {}) {
+    this.version = settings.version !== undefined ? settings.version : 1;
+    this._registerSettings(settings);
+  }
 
-    // model defaults
-    if (options.modelDefaults) {
-      this.modelDefaults = options.modelDefaults;
+  /**
+   * Upgrades Schema to a new version with new settings.
+   *
+   * Emits the `upgrade` event to cue sources to upgrade their data.
+   *
+   * @param {Object}   [settings={}]
+   * @param {Integer}  [settings.version]       Optional. Schema version. Defaults to the current version + 1.
+   * @param {Object}   [settings.models]        Schemas for individual models supported by this schema.
+   * @param {Object}   [settings.modelDefaults] Optional. Defaults for model schemas.
+   * @param {Function} [settings.pluralize]     Optional. Function used to pluralize names.
+   * @param {Function} [settings.singularize]   Optional. Function used to singularize names.
+   */
+  upgrade(settings = {}) {
+    this.version = settings.version !== undefined ? settings.version : (this.version + 1);
+    this._registerSettings(settings);
+    this.emit('upgrade', this.version);
+  }
+
+  /**
+   * Registers a complete set of settings
+   *
+   * @param {Object} [settings={}] Settings passed into `constructor` or `upgrade`
+   */
+  _registerSettings(settings = {}) {
+    // Set inflection functions
+    if (settings.pluralize) {
+      this.pluralize = settings.pluralize;
+    }
+    if (settings.singularize) {
+      this.singularize = settings.singularize;
+    }
+
+    // Set model schema defaults
+    if (settings.modelDefaults) {
+      this.modelDefaults = settings.modelDefaults;
     } else {
       this.modelDefaults = {
         id: { defaultValue: uuid }
       };
     }
 
-    // inflection
-    if (options.pluralize) {
-      this.pluralize = options.pluralize;
-    }
-    if (options.singularize) {
-      this.singularize = options.singularize;
-    }
+    // Register model schemas
+    this._registerModels(settings.models);
+  }
 
-    // register provided model schema
+  /**
+   * Registers the schema of all models.
+   *
+   * @private
+   * @param {Object} models Hash of models, keyed by type
+   */
+  _registerModels(models) {
     this.models = {};
-    if (options.models) {
-      Object.keys(options.models).forEach(modelName => {
-        this._registerModel(modelName, options.models[modelName]);
+    if (models) {
+      Object.keys(models).forEach(modelName => {
+        this._registerModel(modelName, models[modelName]);
       });
     }
   }
 
   /**
-   Registers a model's schema definition.
-
-   @param {String} [name]       name of the model
-   @param {Object} [definition] model schema definition
-   @private
+   * Registers a model's schema definition.
+   *
+   * @private
+   * @param {String} name       Name of the model
+   * @param {Object} definition Model schema definition
    */
   _registerModel(name, definition) {
     this.models[name] = this._mergeModelSchemas({}, this.modelDefaults, definition);
   }
 
   /**
-   Normalizes a record according to its type and corresponding schema
-   definition.
-
-   A record's primary key, relationships, and meta data will all be initialized.
-
-   A record can only be normalized once. A flag is set on the record
-   (`__normalized`) to prevent "re-normalization".
-
-   @param  {Object} [record] record data
-   @return {Object} normalized version of `data`
+   * Normalizes a record according to its type and corresponding schema
+   * definition.
+   *
+   * A record's primary key, relationships, and meta data will all be initialized.
+   *
+   * A record can only be normalized once. A flag is set on the record
+   * (`__normalized`) to prevent "re-normalization".
+   *
+   * @param {Object} record Record data
+   * @return {Object} Normalized version of `data`
    */
   normalize(record) {
     if (record.__normalized) { return record; }
@@ -329,13 +369,12 @@ export default class Schema {
   }
 
   /**
-   Look up a model definition.
-
-   If no model has been defined, a `ModelNotRegisteredException` is raised.
-
-   @method modelDefinition
-   @param {String} type - type of model
-   @return {Object} model definition
+   * Returns a model definition.
+   *
+   * If no model has been defined, a `ModelNotRegisteredException` is raised.
+   *
+   * @param {String} type Type of model
+   * @return {Object} Model definition
    */
   modelDefinition(type) {
     let definition = this.models[type];
@@ -407,10 +446,10 @@ export default class Schema {
   }
 
   /**
-   Generate an id for a given model type.
-
-   @param {String} type - a model type
-   @returns {String} a generated model ID
+   * Generate an id for a given model type.
+   *
+   * @param {String} type A model type
+   * @return {String} Generated model ID
    */
   generateDefaultId(type) {
     let value = this.modelDefinition(type).id.defaultValue;

--- a/test/tests/unit/schema-test.js
+++ b/test/tests/unit/schema-test.js
@@ -96,57 +96,6 @@ test('`modelDefaults` can be overridden', function() {
   equal(Object.keys(model.relationships).length, 0, 'model has no relationships');
 });
 
-test('#registerModel can register models after initialization', function(assert) {
-  const done = assert.async();
-
-  const customIdGenerator = function() {
-    return Math.random().toString(); // don't do this ;)
-  };
-
-  const schema = new Schema({
-    modelDefaults: {
-      id: {
-        defaultValue: customIdGenerator
-      },
-      keys: {
-        remoteId: {}
-      },
-      attributes: {
-        someAttr: {}
-      },
-      relationships: {
-        someLink: {}
-      }
-    },
-    models: {
-      planet: {}
-    }
-  });
-
-  assert.ok(schema.models, 'schema.models has been set');
-  assert.ok(schema.models['planet'], 'model definition has been set');
-  assert.equal(schema.models['moon'], undefined, 'moon\'s definition has NOT been set');
-
-  schema.on('modelRegistered', function(name) {
-    if (name === 'moon') {
-      let model;
-      assert.ok(model = schema.models['moon'], 'model definition has been set');
-      assert.strictEqual(model.id.defaultValue, customIdGenerator, 'model.id.defaultValue has been set');
-      assert.ok(model.keys, 'model.keys has been set');
-      assert.ok(model.attributes, 'model.attributes has been set');
-      assert.ok(model.relationships, 'model.relationships has been set');
-      assert.ok(model.keys.remoteId, 'model.keys.remoteId has been set');
-      assert.equal(Object.keys(model.keys).length, 1, 'model has one key');
-      assert.equal(Object.keys(model.attributes).length, 1, 'model has no attributes');
-      assert.equal(Object.keys(model.relationships).length, 1, 'model has no relationships');
-
-      done();
-    }
-  });
-
-  schema.registerModel('moon', {});
-});
-
 test('#modelDefinition returns a registered model definition', function(assert) {
   const planetDefinition = {
     attributes: {
@@ -172,32 +121,6 @@ test('#modelDefinition throws an exception if a model is not registered', functi
   throws(function() {
     schema.modelDefinition('planet');
   }, ModelNotRegisteredException, 'threw a OC.ModelNotRegisteredException');
-});
-
-test('#modelNotDefined can provide lazy registrations of models', function(assert) {
-  assert.expect(2);
-
-  const schema = new Schema({
-    models: {
-    }
-  });
-
-  const planetDefinition = {
-    attributes: {
-      name: { type: 'string', defaultValue: 'Earth' }
-    }
-  };
-
-  schema.modelNotDefined = function(type) {
-    assert.equal(type, 'planet', 'modelNotDefined called as expected');
-    schema.registerModel('planet', planetDefinition);
-  };
-
-  assert.deepEqual(
-    schema.modelDefinition('planet').attributes,
-    planetDefinition.attributes,
-    'model registered via modelNotDefined hook'
-  );
 });
 
 test('#normalize initializes a record with a unique primary key', function() {
@@ -337,17 +260,6 @@ test('#singularize simply removes a trailing `s` if present at the end of words'
   const schema = new Schema();
   equal(schema.singularize('cows'), 'cow', 'no kine here');
   equal(schema.singularize('data'), 'data', 'no Latin knowledge here');
-});
-
-test('#ensureModelTypeInitialized throws an error when a model type has not been registered', function(assert) {
-  const schema = new Schema({ models: { moon: {} } });
-
-  // No errors when the model is present
-  schema.ensureModelTypeInitialized('moon');
-
-  assert.throws(function() {
-    schema.ensureModelTypeInitialized('planet');
-  }, ModelNotRegisteredException, 'threw a OC.ModelNotRegisteredException');
 });
 
 test('#generateDefaultId', function(assert) {


### PR DESCRIPTION
After working through some issues with browser storage, it's become clear that schemas must be declared eagerly and can not support lazy hooks for defining models.

Schemas now support a `version` as well as an `upgrade` method (and corresponding event). This approach gives sources the opportunity to migrate their data if possible.