### PR TITLE
Remove Immutable.js.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,6 @@ AMD and CJS builds are in `/dist`.
 
 ## Dependencies
 
-Orbit.js is dependent upon [Immutable.js](https://github.com/facebook/immutable-js/)
-for immutable data structures.
-
 Orbit.js must be used in an environment that includes an implementation of the
 [Promises/A+](http://promises-aplus.github.io/promises-spec/). If you wish to
 support legacy browsers, you will need to include a library such as

--- a/build-support/build.js
+++ b/build-support/build.js
@@ -75,7 +75,6 @@ module.exports = function build(pkg, namespace) {
 
   var vendor = concat('', {
     inputFiles: [
-      path.join(require.resolve('immutable'), '..', 'immutable.js'),
       path.join(require.resolve('rsvp'), '..', 'rsvp.js')
     ],
     outputFile: '/assets/vendor.js'

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "keywords": [
     "orbit.js",
     "data",
-    "immutable",
     "synchronization"
   ],
   "engines": {
@@ -47,8 +46,5 @@
     "rsvp": "3.2.1",
     "testem": "1.6.0",
     "yuidocjs": "^0.8.1"
-  },
-  "dependencies": {
-    "immutable": "^3.7.6"
   }
 }

--- a/test/tests/unit/transform-log-test.js
+++ b/test/tests/unit/transform-log-test.js
@@ -1,4 +1,3 @@
-/* globals Immutable */
 import TransformLog from 'orbit/transform/log';
 import { TransformNotLoggedException, OutOfRangeException } from 'orbit/lib/exceptions';
 import { FakeBucket } from 'tests/test-helper';
@@ -16,14 +15,7 @@ module('Orbit - TransformLog', function() {
     assert.equal(log.length, 0, 'log has expected size');
   });
 
-  test('can be instantiated with immutable list data', function(assert) {
-    let data = new Immutable.List(['a', 'b']);
-    log = new TransformLog(data);
-    assert.ok(log, 'log instantiated');
-    assert.strictEqual(log.data, data, 'log has expected data');
-  });
-
-  test('can be instantiated with a normal JS array', function(assert) {
+  test('can be instantiated with an array', function(assert) {
     log = new TransformLog(['a', 'b']);
     assert.ok(log, 'log instantiated');
     assert.equal(log.length, 2, 'log has expected data');
@@ -39,11 +31,10 @@ module('Orbit - TransformLog', function() {
     });
 
     test('#append', function(assert) {
-      assert.expect(3);
+      assert.expect(2);
 
-      log.on('append', (transformIds, data) => {
+      log.on('append', (transformIds) => {
         assert.deepEqual(transformIds, [transformAId], 'append event emits transform');
-        assert.strictEqual(data.size, 0, 'append event emits prev state');
       });
 
       return log.append(transformAId)
@@ -68,9 +59,8 @@ module('Orbit - TransformLog', function() {
       );
     });
 
-    test('#data', function(assert) {
-      assert.ok(Immutable.List.isList(log.data), 'is immutable');
-      assert.equal(log.data.size, 3, 'contains the expected transforms');
+    test('#entries', function(assert) {
+      assert.equal(log.entries.length, 3, 'contains the expected transforms');
     });
 
     test('#length', function(assert) {
@@ -129,8 +119,8 @@ module('Orbit - TransformLog', function() {
     test('#clear', function(assert) {
       assert.expect(2);
 
-      log.on('clear', (data) => {
-        assert.strictEqual(data.size, 3, 'clear event emits prev state');
+      log.on('clear', () => {
+        assert.ok(true, 'clear event emitted');
       });
 
       return log.clear()
@@ -140,12 +130,11 @@ module('Orbit - TransformLog', function() {
     });
 
     test('#truncate', function(assert) {
-      assert.expect(4);
+      assert.expect(3);
 
-      log.on('truncate', (transformId, relativePosition, data) => {
+      log.on('truncate', (transformId, relativePosition) => {
         assert.strictEqual(transformId, transformBId, 'truncate event emits transform');
         assert.strictEqual(relativePosition, 0, 'truncate event emits relativePosition');
-        assert.strictEqual(data.size, 3, 'truncate event emits prev state');
       });
 
       return log.truncate(transformBId)
@@ -190,12 +179,11 @@ module('Orbit - TransformLog', function() {
     });
 
     test('#rollback', function(assert) {
-      assert.expect(4);
+      assert.expect(3);
 
-      log.on('rollback', (transformId, relativePosition, data) => {
+      log.on('rollback', (transformId, relativePosition) => {
         assert.strictEqual(transformId, transformAId, 'rollback event emits transform');
         assert.strictEqual(relativePosition, 0, 'rollback event emits relativePosition');
-        assert.strictEqual(data.size, 3, 'rollback event emits prev state');
       });
 
       return log.rollback(transformAId)
@@ -267,7 +255,7 @@ module('Orbit - TransformLog', function() {
           return log.reified;
         })
         .then(() => {
-          assert.equal(log.data.size, 2, 'log contains the expected transforms');
+          assert.equal(log.length, 2, 'log contains the expected transforms');
         });
     });
 
@@ -292,7 +280,7 @@ module('Orbit - TransformLog', function() {
       return log.append(transformAId, transformBId, transformCId)
         .then(() => log.truncate(log.head))
         .then(() => {
-          assert.equal(log.data.size, 1, 'log contains the expected transforms');
+          assert.equal(log.length, 1, 'log contains the expected transforms');
           return bucket.getItem('log');
         })
         .then(logged => {
@@ -307,7 +295,7 @@ module('Orbit - TransformLog', function() {
       return log.append(transformAId, transformBId, transformCId)
         .then(() => log.rollback(transformBId))
         .then(() => {
-          assert.equal(log.data.size, 2, 'log contains the expected transforms');
+          assert.equal(log.length, 2, 'log contains the expected transforms');
           return bucket.getItem('log');
         })
         .then(logged => {
@@ -322,7 +310,7 @@ module('Orbit - TransformLog', function() {
       return log.append(transformAId, transformBId, transformCId)
         .then(() => log.clear())
         .then(() => {
-          assert.equal(log.data.size, 0, 'log contains the expected transforms');
+          assert.equal(log.length, 0, 'log contains the expected transforms');
           return bucket.getItem('log');
         })
         .then(logged => {


### PR DESCRIPTION
Immutable was not strictly needed in orbit-core. It was used within
TransformLog, but events that emitted prior log state have not proven
to be useful so far.

A dependency on an immutable library will likely be limited to 
orbit-store, where it’s truly needed within the Cache.