### PR TITLE
`set` accessor returns whether mutation occurred

### DIFF
--- a/src/lib/objects.js
+++ b/src/lib/objects.js
@@ -198,37 +198,24 @@ function get(obj, path) {
   @param {Object} obj - object to set values in
   @param {string[]} path - any array of strings specifying the path to use
   @param {*} value - the value to set
-  @returns {undefined}
+  @returns {boolean} - was the value was actually changed?
  */
 function set(obj, path, value) {
-  let index = -1;
-  let length = path.length;
-  let lastIndex = length - 1;
-  let nested = obj;
-
-  /* eslint-disable no-eq-null, eqeqeq */
-  while (nested != null && ++index < length) {
-    let key = path[index];
-
-    if (typeof nested === 'object') {
-      let newValue = value;
-
-      if (index != lastIndex) {
-        let objValue = nested[key];
-
-        if (objValue == null) {
-          newValue = (typeof path[index + 1] === 'number') ? [] : {};
-        } else {
-          newValue = objValue;
-        }
-      }
-
-      nested[key] = newValue;
+  let ptr = obj;
+  let prop = path.pop();
+  let segment;
+  for (let i = 0, l = path.length; i < l; i++) {
+    segment = path[i];
+    if (ptr[segment] === undefined) {
+      ptr[segment] = (typeof segment === 'number') ? [] : {};
     }
-
-    nested = nested[key];
+    ptr = ptr[segment];
   }
-  /* eslint-enable no-eq-null, eqeqeq */
+  if (ptr[prop] === value) {
+    return false;
+  } else {
+    ptr[prop] = value;
+    return true;
+  }
 }
-
 export { clone, expose, extend, isArray, toArray, isObject, isNone, merge, get, set };

--- a/test/lib/object-test.js
+++ b/test/lib/object-test.js
@@ -1,4 +1,4 @@
-import { clone, expose, extend, isArray, toArray, isObject, isNone, merge } from '../../src/lib/objects';
+import { clone, expose, extend, isArray, toArray, isObject, isNone, merge, get, set } from '../../src/lib/objects';
 
 const { module, test } = QUnit;
 
@@ -161,5 +161,43 @@ module('Lib / Object', function() {
     assert.deepEqual(merge(a, b), expected, 'Object values are not merged');
     assert.deepEqual(a, { firstNames: 'Bob', underling: false },
               'Original object mutated');
+  });
+
+  test('`get` retrieves a value from a nested object', function(assert) {
+    let obj = {
+      author: {
+        name: {
+          first: 'Ginkgo'
+        }
+      }
+    };
+
+    assert.equal(get(obj, ['author', 'name', 'first']), 'Ginkgo', 'returns a match');
+    assert.equal(get(obj, ['author', 'name', 'last']), undefined, 'returns undefined if no match');
+  });
+
+  test('`set` sets a value on an object, creating objects/arrays as needed', function(assert) {
+    let obj = {};
+
+    let ret = set(obj, ['name'], 'Ginkgo');
+
+    assert.deepEqual(obj, { name: 'Ginkgo' }, 'simple set one level deep');
+    assert.equal(ret, true, 'object was mutated');
+
+    ret = set(obj, ['appendages', 'feet'], 4);
+
+    assert.deepEqual(obj, { name: 'Ginkgo', appendages: { feet: 4 } }, 'simple set one level deep');
+    assert.equal(ret, true, 'object was mutated');
+
+    let owner = { name: 'dgeb' };
+
+    ret = set(obj, ['owner'], owner);
+    assert.equal(ret, true, 'object was mutated');
+
+    ret = set(obj, ['owner'], owner);
+    assert.equal(ret, false, 'object was not mutated');
+
+    ret = set(obj, ['toys', 2], 'blue chewy');
+    assert.equal(obj.toys[2], 'blue chewy', 'set can add array members too');
   });
 });


### PR DESCRIPTION
`set` will perform a strict equality check to verify whether a mutation
is needed - and return `false` if not.